### PR TITLE
Permuting mongo check script and Postgres check script

### DIFF
--- a/stable/xray/templates/xray-setup-conf.yaml
+++ b/stable/xray/templates/xray-setup-conf.yaml
@@ -21,14 +21,15 @@ data:
     mkdir -pv ${XRAY_CONFIG_DIR}
 
     # Wait for DBs to be ready
-    echo "Waiting for DBs..."
     {{- if .Values.mongodb.enabled }}
-    until nc -z -w 2 {{ .Release.Name }}-postgresql {{ .Values.postgresql.service.port }} && echo postgresql ok; do
+    echo "Waiting for Mongo..."
+    until nc -z -w 2 {{ .Release.Name }}-mongodb 27017 && echo mongodb ok; do
       sleep 2;
     done;
     {{- end }}
     {{- if .Values.postgresql.enabled }}
-    until nc -z -w 2 {{ .Release.Name }}-mongodb 27017 && echo mongodb ok; do
+    echo "Waiting for Postgres..."
+    until nc -z -w 2 {{ .Release.Name }}-postgresql {{ .Values.postgresql.service.port }} && echo postgresql ok; do
       sleep 2;
     done;
     {{- end }}
@@ -77,4 +78,3 @@ data:
         stdOutEnabled:  {{ .Values.common.stdOutEnabled }}
         skipEntLicCheckForCloud: true
     # End generated config
-


### PR DESCRIPTION
<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: 
This is a bug in the setup.sh script that's used to bootstrap containers which rely on Postgres/mongo. The surrounding code guards referred to the wrong `enabled` options. Solution was to permute the check blocks. Also added an additional `echo`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: