### PR TITLE
Adds a PodDisruptionBudget for the member nodes

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All notable changes to this chart will be documented in this file.
 
+## [0.4.6] - Sep 25, 2018
+* Add PodDisruptionBudget for member nodes, defaulting to minAvailable of 1
+
 ## [0.4.4] - Sep 2, 2018
 * Updated Artifactory version to 6.3.2
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.4.5
+version: 0.4.6
 appVersion: 6.3.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -369,7 +369,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.primary.javaOpts.xms`              | Artifactory primary node java Xms size           |                     |
 | `artifactory.primary.javaOpts.xmx`              | Artifactory primary node java Xms size           |                     |
 | `artifactory.primary.javaOpts.other`            | Artifactory primary node additional java options |                     |
-| `artifactory.node.replicaCount`                 | Artifactory member node replica count            | `1`                 |
+| `artifactory.node.replicaCount`                 | Artifactory member node replica count            | `2`                 |
+| `artifactory.node.minAvailable`                 | Artifactory member node min available count      | `1`                 |
 | `artifactory.node.resources.requests.memory`    | Artifactory member node initial memory request   |                     |
 | `artifactory.node.resources.requests.cpu`       | Artifactory member node initial cpu request      |                     |
 | `artifactory.node.resources.limits.memory`      | Artifactory member node memory limit             |                     |

--- a/stable/artifactory-ha/templates/artifactory-node-pdb.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-pdb.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "artifactory-ha.fullname" . }}-node
+  labels:
+    app: {{ template "artifactory-ha.name" . }}
+    chart: {{ template "artifactory-ha.chart" . }}
+    component: {{ .Values.artifactory.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "artifactory-ha.name" . }}
+      role: {{ template "artifactory-ha.node.name" . }}
+      release: {{ .Release.Name }}
+  minAvailable: {{ .Values.artifactory.node.minAvailable }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -239,6 +239,7 @@ artifactory:
       ## If true, you must prepare a PVC with the name e.g `artifactory-ha-member`
       existingClaim: false
     replicaCount: 2
+    minAvailable: 1
     ## Resources for the member nodes
     resources: {}
     #  requests:


### PR DESCRIPTION
This ensures that during a rolling update of a cluster, one of the
member nodes will always be up serving traffic.