### PR TITLE
Missing quote for ingress host names in all charts

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All notable changes to this chart will be documented in this file.
 
+## [0.5.3] - Oct 9, 2018
+* Quote ingress hosts to support wildcard names
+
 ## [0.5.2] - Oct 2, 2018
 * Add `helm repo add jfrog https://charts.jfrog.io` to README
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.5.2
+version: 0.5.3
 appVersion: 6.4.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/ingress.yaml
+++ b/stable/artifactory-ha/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
 {{- if .Values.ingress.hosts }}
   rules:
   {{- range $host := .Values.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
         - path: /

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All notable changes to this chart will be documented in this file.
 
+## [7.5.4] - Oct 9, 2018
+* Quote ingress hosts to support wildcard names
+
 ## [7.5.3] - Oct 4, 2018
 * Add PostgreSQL resources template
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.5.3
+version: 7.5.4
 appVersion: 6.4.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/ingress.yaml
+++ b/stable/artifactory/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
 {{- if .Values.ingress.hosts }}
   rules:
   {{- range $host := .Values.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
         - path: /

--- a/stable/distribution/CHANGELOG.md
+++ b/stable/distribution/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Distribution Chart Changelog
 All notable changes to this project chart be documented in this file.
 
+## [1.0.5] - Oct 9, 2018
+* Quote ingress hosts to support wildcard names
+
 ## [1.0.4] - Oct 8, 2018
 * Fix distribution to use mongodb credentials secret
 

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: distribution
 description: A Helm chart for JFrog Distribution
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.2.0
 home: https://jfrog.com/platform/
 icon: https://raw.githubusercontent.com/jfrog/artifactory-dcos/master/images/jfrog_med.png

--- a/stable/distribution/templates/ingress.yaml
+++ b/stable/distribution/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
 {{- if .Values.ingress.hosts }}
   rules:
   {{- range $host := .Values.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
         - path: /

--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Mission-Control Chart Changelog
 All notable changes to this chart will be documented in this file.
 
+## [0.4.5] - Oct 9, 2018
+* Quote ingress hosts to support wildcard names
+
 ## [0.4.4] - Oct 2, 2018
 * Add `helm repo add jfrog https://charts.jfrog.io` to README
 

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 description: A Helm chart for JFrog Mission Control
-version: 0.4.4
+version: 0.4.5
 appVersion: 3.1.2
 home: https://jfrog.com/mission-control/
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png

--- a/stable/mission-control/templates/ingress.yaml
+++ b/stable/mission-control/templates/ingress.yaml
@@ -20,14 +20,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All notable changes to this chart will be documented in this file.
 
+## [0.5.6] - Oct 9, 2018
+* Quote ingress hosts to support wildcard names
+
 ## [0.5.5] - Oct 2, 2018
 * Add `helm repo add jfrog https://charts.jfrog.io` to README
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.5.5
+version: 0.5.6
 appVersion: 2.3.3
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/templates/ingress.yaml
+++ b/stable/xray/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
 {{- if .Values.ingress.hosts }}
   rules:
   {{- range $host := .Values.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
         - path: /


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable using host names beginings with '*' in ingress

**Which issue this PR fixes**

fixes #71 

**Special notes for your reviewer**:

As it is a minor change, i didn't update the changelog and the version of all charts
