### PR TITLE
Update postgresql chart version to 0.9.5

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.0] - Oct 28, 2018
+* Update postgresql chart to version 0.9.5 to be able and use `postgresConfig` options
+
 ## [0.6.9] - Oct 23, 2018
 * Fix providing external secret for database credentials
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.6.9
+version: 0.7.0
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/ci/test-values.yaml
+++ b/stable/artifactory-ha/ci/test-values.yaml
@@ -3,6 +3,9 @@ artifactory:
     enabled: false
 
 postgresql:
+  postgresPassword: "password"
+  postgresConfig:
+    maxConnections: "102"
   persistence:
     enabled: false
 

--- a/stable/artifactory-ha/requirements.lock
+++ b/stable/artifactory-ha/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.8.7
-digest: sha256:02e9e88b9a147c956d857fb8874f16257b90fc980522b329f3257979811af7f7
-generated: 2018-01-17T15:55:26.174758+02:00
+  version: 0.9.5
+digest: sha256:7e07fb616d953e518e3373e2c5183290b4b6e94292a233528c0d52ffd42afc77
+generated: 2018-10-28T06:26:39.466565306+02:00

--- a/stable/artifactory-ha/requirements.yaml
+++ b/stable/artifactory-ha/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: 0.8.7
+  version: 0.9.5
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.7.0] - Oct 28, 2018
+* Update postgresql chart to version 0.9.5 to be able and use `postgresConfig` options
+
 ## [7.6.8] - Oct 23, 2018
 * Fix providing external secret for database credentials
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.6.8
+version: 7.7.0
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/ci/test-values.yaml
+++ b/stable/artifactory/ci/test-values.yaml
@@ -3,6 +3,9 @@ artifactory:
     enabled: false
 
 postgresql:
+  postgresPassword: "password"
+  postgresConfig:
+    maxConnections: "102"
   persistence:
     enabled: false
 

--- a/stable/artifactory/requirements.lock
+++ b/stable/artifactory/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.8.7
-digest: sha256:02e9e88b9a147c956d857fb8874f16257b90fc980522b329f3257979811af7f7
-generated: 2018-05-18T16:12:27.72899131-07:00
+  version: 0.9.5
+digest: sha256:7e07fb616d953e518e3373e2c5183290b4b6e94292a233528c0d52ffd42afc77
+generated: 2018-10-28T06:16:23.130221158+02:00

--- a/stable/artifactory/requirements.yaml
+++ b/stable/artifactory/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: 0.8.7
+    version: 0.9.5
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled


### PR DESCRIPTION
Update `postgresql` chart version to 0.9.5.
This is important to be able and use the `postgresConfig` parameter of the `postgresql` chart.