### PR TITLE
Adds support for arbitrary User Plugins

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.2] - Nov 1, 2018
+* Allow specification of arbitrary [User Plugins](https://www.jfrog.com/confluence/display/RTF/User+Plugins)
+
 ## [0.7.1] - Oct 29, 2018
 * Change probes port to 8040 (so they will not be blocked when all tomcat threads on 8081 are exhausted)
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.7.1
+version: 0.7.2
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-plugins.yaml
+++ b/stable/artifactory-ha/templates/artifactory-plugins.yaml
@@ -1,13 +1,16 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ template "artifactory-ha.fullname" . }}-isc
+  name: {{ template "artifactory-ha.fullname" . }}-plugins
   labels:
     app: {{ template "artifactory-ha.name" . }}
     chart: {{ template "artifactory-ha.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
+{{- if .Values.artifactory.plugins }}
+{{ .Values.artifactory.plugins | toYaml | indent 2 -}}
+{{- end }}
   inactiveServerCleaner.groovy: |-
     import org.artifactory.state.ArtifactoryServerState
     import org.artifactory.storage.db.servers.service.ArtifactoryServersCommonService

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/binarystore: {{ include (print $.Template.BasePath "/artifactory-binarystore.yaml") . | sha256sum }}
+        checksum/plugins: {{ include (print $.Template.BasePath "/artifactory-plugins.yaml") . | sha256sum }}
       {{- range $key, $value := .Values.artifactory.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -113,6 +113,15 @@ artifactory:
   masterKey: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
   # masterKeySecretName:
 
+  # Load User Plugins (https://www.jfrog.com/confluence/display/RTF/User+Plugins)
+  plugins:
+    # dummyPlugin.groovy: |
+    #   executions {
+    #       dummyPlugin(users: ['anonymous']) {
+    #           message = '{"status":"okay"}'
+    #           status = 200
+    #       }
+    #   }
 
   ## Artifactory license secret.
   ## If artifactory.license.secret is passed, it will be mounted as


### PR DESCRIPTION
See https://www.jfrog.com/confluence/display/RTF/User+Plugins for
examples on how to write User Plugins.

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: 
This adds support for providing arbitrary User Plugins deployed to Artifactory HA.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
