### PR TITLE
Support Artifactory db url

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.2] - Nov 7, 2018
+* Support database.url parameter (DB_URL)
+
 ## [0.7.1] - Oct 29, 2018
 * Change probes port to 8040 (so they will not be blocked when all tomcat threads on 8081 are exhausted)
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.7.1
+version: 0.7.2
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -485,6 +485,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `database.secrets.user.key`      | External database username `Secret` key            |                                         |
 | `database.secrets.password.name` | External database password `Secret` name           |                                         |
 | `database.secrets.password.key`  | External database password `Secret` key            |                                         |
+| `database.secrets.url.name     ` | External database url `Secret` name                |                                         |
+| `database.secrets.url.key`       | External database url `Secret` key                 |                                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -478,6 +478,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `database.type`                  | External database type (`postgresql`, `mysql`, `oracle` or `mssql`)  |                       |
 | `database.host`                  | External database hostname                         |                                         |
 | `database.port`                  | External database port                             |                                         |
+| `database.url`                   | External database connection URL                   |                                         |
 | `database.user`                  | External database username                         |                                         |
 | `database.password`              | External database password                         |                                         |
 | `database.secrets.user.name`     | External database username `Secret` name           |                                         |

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -108,28 +108,38 @@ spec:
               key: postgres-password
       {{- else }}
         - name: DB_TYPE
-          value: '{{ .Values.database.type }}'
-        {{- if .Values.database.url }}
+          value: '{{ required "Must set database.type when not using the PostgreSQL sub-chart (postgresql.enabled=false) " .Values.database.type }}'
+        {{- if or .Values.database.url .Values.database.secrets.url }}
         - name: DB_URL
+        {{- if .Values.database.url }}
           value: '{{.Values.database.url }}'
+        {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.secrets.url.name }}
+              key: {{ .Values.database.secrets.url.key }}
+        {{- end }}
         {{- else }}
         - name: DB_HOST
           value: '{{ .Values.database.host }}'
         - name: DB_PORT
           value: '{{ .Values.database.port }}'
         {{- end }}
-      {{- if .Values.database.secrets }}
+        {{- if .Values.database.secrets.user }}
         - name: DB_USER
           valueFrom:
             secretKeyRef:
               name: {{ .Values.database.secrets.user.name }}
               key: {{ .Values.database.secrets.user.key }}
+        {{- end }}
+        {{- if .Values.database.secrets.password }}
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.database.secrets.password.name }}
               key: {{ .Values.database.secrets.password.key }}
-      {{- else }}
+        {{- else }}
+        {{- if and .Values.database.type .Values.database.user }}
         - name: DB_USER
           value: '{{ .Values.database.user }}'
         - name: DB_PASSWORD
@@ -137,7 +147,8 @@ spec:
             secretKeyRef:
               name: {{ template "artifactory-ha.fullname" . }}
               key: db-password
-      {{- end }}
+        {{- end }}
+        {{- end }}
       {{- end }}
         - name: EXTRA_JAVA_OPTIONS
           value: "

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -100,7 +100,7 @@ spec:
         - name: DB_PORT
           value: '{{ .Values.postgresql.service.port }}'
         - name: DB_USER
-          value: '{{.Values.postgresql.postgresUser }}'
+          value: '{{ .Values.postgresql.postgresUser }}'
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -109,10 +109,15 @@ spec:
       {{- else }}
         - name: DB_TYPE
           value: '{{ .Values.database.type }}'
+        {{- if .Values.database.url }}
+        - name: DB_URL
+          value: '{{.Values.database.url }}'
+        {{- else }}
         - name: DB_HOST
           value: '{{ .Values.database.host }}'
         - name: DB_PORT
           value: '{{ .Values.database.port }}'
+        {{- end }}
       {{- if .Values.database.secrets }}
         - name: DB_USER
           valueFrom:

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -111,7 +111,7 @@ spec:
               key: postgres-password
       {{- else }}
         - name: DB_TYPE
-          value: '{{ .Values.database.type }}'
+          value: '{{ required "Must set database.type when not using the PostgreSQL sub-chart (postgresql.enabled=false) " .Values.database.type }}'
         {{- if .Values.database.url }}
         - name: DB_URL
           value: '{{.Values.database.url }}'

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
               - '-c'
               - >
                 {{- if .Values.artifactory.configMapName }}
-                cp -Lrfv /bootstrap/* /artifactory_extra_conf/
+                cp -Lrf /bootstrap/* /artifactory_extra_conf/;
                 {{- end }}
                 {{- if .Values.artifactory.replicator.enabled }}
                 mkdir -p {{ .Values.artifactory.persistence.mountPath }}/replicator/etc;
@@ -112,27 +112,37 @@ spec:
       {{- else }}
         - name: DB_TYPE
           value: '{{ required "Must set database.type when not using the PostgreSQL sub-chart (postgresql.enabled=false) " .Values.database.type }}'
-        {{- if .Values.database.url }}
+        {{- if or .Values.database.url .Values.database.secrets.url }}
         - name: DB_URL
+        {{- if .Values.database.url }}
           value: '{{.Values.database.url }}'
+        {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.secrets.url.name }}
+              key: {{ .Values.database.secrets.url.key }}
+        {{- end }}
         {{- else }}
         - name: DB_HOST
           value: '{{ .Values.database.host }}'
         - name: DB_PORT
           value: '{{ .Values.database.port }}'
         {{- end }}
-      {{- if .Values.database.secrets }}
+        {{- if .Values.database.secrets.user }}
         - name: DB_USER
           valueFrom:
             secretKeyRef:
               name: {{ .Values.database.secrets.user.name }}
               key: {{ .Values.database.secrets.user.key }}
+        {{- end }}
+        {{- if .Values.database.secrets.password }}
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.database.secrets.password.name }}
               key: {{ .Values.database.secrets.password.key }}
-      {{- else }}
+        {{- else }}
+        {{- if and .Values.database.type .Values.database.user }}
         - name: DB_USER
           value: '{{ .Values.database.user }}'
         - name: DB_PASSWORD
@@ -140,7 +150,8 @@ spec:
             secretKeyRef:
               name: {{ template "artifactory-ha.fullname" . }}
               key: db-password
-      {{- end }}
+        {{- end }}
+        {{- end }}
       {{- end }}
         - name: EXTRA_JAVA_OPTIONS
           value: "

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -112,10 +112,15 @@ spec:
       {{- else }}
         - name: DB_TYPE
           value: '{{ .Values.database.type }}'
+        {{- if .Values.database.url }}
+        - name: DB_URL
+          value: '{{.Values.database.url }}'
+        {{- else }}
         - name: DB_HOST
           value: '{{ .Values.database.host }}'
         - name: DB_PORT
           value: '{{ .Values.database.port }}'
+        {{- end }}
       {{- if .Values.database.secrets }}
         - name: DB_USER
           valueFrom:

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -82,6 +82,8 @@ database:
   type:
   host:
   port:
+  ## If you set the url, leave host and port empty
+  url:
   ## If you would like this chart to create the secret containing the db
   ## password, use these values
   user:

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -97,6 +97,9 @@ database:
   #  password:
   #    name: "rds-artifactory"
   #    key: "db-password"
+  #  url:
+  #    name: "rds-artifactory"
+  #    key: "db-url"
 
 # Artifactory
 artifactory:

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -77,7 +77,7 @@ postgresql:
   #    cpu: "500m"
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
-## you must specify the following database details
+## you MUST specify custom database details here or Artifactory will NOT start
 database:
   type:
   host:

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.7.2] - Nov 7, 2018
+* Support database.url parameter (DB_URL)
+
 ## [7.7.1] - Oct 29, 2018
 * Change probes port to 8040 (so they will not be blocked when all tomcat threads on 8081 are exhausted)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.7.1
+version: 7.7.2
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -187,6 +187,8 @@ kubectl create secret generic my-secret --from-literal=user=${DB_USER} --from-li
 --set database.secrets.user.key=user \
 --set database.secrets.password.name=my-secret \
 --set database.secrets.password.key=password \
+--set database.secrets.url.name=my-secret \
+--set database.secrets.url.key=url \
 ...
 ```
 
@@ -329,6 +331,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `database.secrets.user.key`      | External database username `Secret` key            |                                         |
 | `database.secrets.password.name` | External database password `Secret` name           |                                         |
 | `database.secrets.password.key`  | External database password `Secret` key            |                                         |
+| `database.secrets.url.name     ` | External database url `Secret` name                |                                         |
+| `database.secrets.url.key`       | External database url `Secret` key                 |                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -308,6 +308,27 @@ The following table lists the configurable parameters of the artifactory chart a
 | `nginx.resources.requests.cpu`    | Nginx initial cpu request     |                                                      |
 | `nginx.resources.limits.memory`   | Nginx memory limit            |                                                      |
 | `nginx.resources.limits.cpu`      | Nginx cpu limit               |                                                      |
+| `postgresql.enabled`              | Use enclosed PostgreSQL as database        | `true`                                  |
+| `postgresql.postgresDatabase`     | PostgreSQL database name                   | `artifactory`                           |
+| `postgresql.postgresUser`         | PostgreSQL database user                   | `artifactory`                           |
+| `postgresql.postgresPassword`     | PostgreSQL database password               |                                         |
+| `postgresql.persistence.enabled`  | PostgreSQL use persistent storage          | `true`                                  |
+| `postgresql.persistence.size`     | PostgreSQL persistent storage size         | `50Gi`                                  |
+| `postgresql.service.port`         | PostgreSQL database port                   | `5432`                                  |
+| `postgresql.resources.requests.memory`    | PostgreSQL initial memory request  |                                         |
+| `postgresql.resources.requests.cpu`       | PostgreSQL initial cpu request     |                                         |
+| `postgresql.resources.limits.memory`      | PostgreSQL memory limit            |                                         |
+| `postgresql.resources.limits.cpu`         | PostgreSQL cpu limit               |                                         |
+| `database.type`                  | External database type (`postgresql`, `mysql`, `oracle` or `mssql`)  |                       |
+| `database.host`                  | External database hostname                         |                                         |
+| `database.port`                  | External database port                             |                                         |
+| `database.url`                   | External database connection URL                   |                                         |
+| `database.user`                  | External database username                         |                                         |
+| `database.password`              | External database password                         |                                         |
+| `database.secrets.user.name`     | External database username `Secret` name           |                                         |
+| `database.secrets.user.key`      | External database username `Secret` key            |                                         |
+| `database.secrets.password.name` | External database password `Secret` name           |                                         |
+| `database.secrets.password.key`  | External database password `Secret` key            |                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -58,7 +58,11 @@ spec:
       {{- if .Values.postgresql.enabled }}
           until nc -z -w 2 {{ .Release.Name }}-postgresql {{ .Values.postgresql.service.port }} && echo database ok; do
       {{- else }}
+        {{- if and .Values.database.host .Values.database.port }}
           until nc -z -w 2 {{ .Values.database.host }} {{ .Values.database.port }} && echo database ok; do
+        {{- else }}
+          until true; do
+        {{- end }}
       {{- end }}
             sleep 2;
           done;
@@ -128,6 +132,7 @@ spec:
               name: {{ .Values.database.secrets.password.name }}
               key: {{ .Values.database.secrets.password.key }}
         {{- else }}
+        {{- if .Values.database.type }}
         - name: DB_USER
           value: '{{ .Values.database.user }}'
         - name: DB_PASSWORD
@@ -135,6 +140,7 @@ spec:
             secretKeyRef:
               name: {{ template "artifactory.fullname" . }}
               key: db-password
+        {{- end }}
         {{- end }}
       {{- end }}
         - name: ARTIFACTORY_MASTER_KEY

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -92,7 +92,7 @@ spec:
                 {{ .Values.artifactory.postStartCommand }}
                 {{- end }}
         env:
-        {{- if .Values.postgresql.enabled }}
+      {{- if .Values.postgresql.enabled }}
         - name: DB_TYPE
           value: 'postgresql'
         - name: DB_USER
@@ -104,13 +104,18 @@ spec:
               key: postgres-password
         - name: DB_HOST
           value: {{ .Release.Name }}-postgresql
-        {{- else }}
+      {{- else }}
         - name: DB_TYPE
           value: '{{ .Values.database.type }}'
+        {{- if .Values.database.url }}
+        - name: DB_URL
+          value: '{{.Values.database.url }}'
+        {{- else }}
         - name: DB_HOST
           value: '{{ .Values.database.host }}'
         - name: DB_PORT
           value: '{{ .Values.database.port }}'
+        {{- end }}
         {{- if .Values.database.secrets }}
         - name: DB_USER
           valueFrom:

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
           done;
       containers:
       - name: {{ .Values.artifactory.name }}
-        image: "{{ .Values.artifactory.image.repository }}:{{ default .Chart.AppVersion .Values.artifactory.image.version }}"
+        image: '{{ .Values.artifactory.image.repository }}:{{ default .Chart.AppVersion .Values.artifactory.image.version }}'
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -99,6 +99,10 @@ spec:
       {{- if .Values.postgresql.enabled }}
         - name: DB_TYPE
           value: 'postgresql'
+        - name: DB_HOST
+          value: '{{ .Release.Name }}-postgresql'
+        - name: DB_PORT
+          value: '{{ .Values.postgresql.service.port }}'
         - name: DB_USER
           value: {{.Values.postgresql.postgresUser | quote }}
         - name: DB_PASSWORD
@@ -106,33 +110,40 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-postgresql
               key: postgres-password
-        - name: DB_HOST
-          value: {{ .Release.Name }}-postgresql
       {{- else }}
         - name: DB_TYPE
           value: '{{ .Values.database.type }}'
-        {{- if .Values.database.url }}
+        {{- if or .Values.database.url .Values.database.secrets.url }}
         - name: DB_URL
+        {{- if .Values.database.url }}
           value: '{{.Values.database.url }}'
+        {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.database.secrets.url.name }}
+              key: {{ .Values.database.secrets.url.key }}
+        {{- end }}
         {{- else }}
         - name: DB_HOST
           value: '{{ .Values.database.host }}'
         - name: DB_PORT
           value: '{{ .Values.database.port }}'
         {{- end }}
-        {{- if .Values.database.secrets }}
+        {{- if .Values.database.secrets.user }}
         - name: DB_USER
           valueFrom:
             secretKeyRef:
               name: {{ .Values.database.secrets.user.name }}
               key: {{ .Values.database.secrets.user.key }}
+        {{- end }}
+        {{- if .Values.database.secrets.password }}
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.database.secrets.password.name }}
               key: {{ .Values.database.secrets.password.key }}
         {{- else }}
-        {{- if .Values.database.type }}
+        {{- if and .Values.database.type .Values.database.user }}
         - name: DB_USER
           value: '{{ .Values.database.user }}'
         - name: DB_PASSWORD
@@ -146,7 +157,7 @@ spec:
         - name: ARTIFACTORY_MASTER_KEY
           valueFrom:
             secretKeyRef:
-              name: "{{ .Values.artifactory.masterKeySecretName | default (include "artifactory.fullname" .) }}"
+              name: '{{ .Values.artifactory.masterKeySecretName | default (include "artifactory.fullname" .) }}'
               key: master-key
         - name: EXTRA_JAVA_OPTIONS
           value: "

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -270,6 +270,8 @@ database:
   type:
   host:
   port:
+  ## If you set the url, leave host and port empty
+  url:
   ## If you would like this chart to create the secret containing the db
   ## password, use these values
   user:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -265,7 +265,7 @@ postgresql:
   #    cpu: "500m"
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
-## you must specify the following database details
+## specify custom database details here or leave empty and Artifactory will use embedded derby
 database:
   type:
   host:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -285,3 +285,6 @@ database:
   #  password:
   #    name: "rds-artifactory"
   #    key: "db-password"
+  #  url:
+  #    name: "rds-artifactory"
+  #    key: "db-url"


### PR DESCRIPTION
When not using the PostgreSQL sub-chart, add support for setting `DB_URL` with `database.url`.