### PR TITLE
Allow pod anti-affinity settings to include primary node

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,7 +1,10 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [0.7.1] - Oct 29, 2018
+## [0.7.2] - Oct 29, 2018
+* Allow pod anti-affinity settings to include primary node
+
+## [0.7.1] - Nov 13, 2018
 * Change probes port to 8040 (so they will not be blocked when all tomcat threads on 8081 are exhausted)
 
 ## [0.7.0] - Oct 28, 2018

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.7.1
+version: 0.7.2
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -244,7 +244,9 @@ spec:
                 matchLabels:
                   app: {{ template "artifactory-ha.name" . }}
                   release: {{ .Release.Name }}
+                  {{- if eq .Values.artifactory.service.pool "members" }}
                   role: {{ template "artifactory-ha.node.name" . }}
+                  {{- end }}
     {{- else if eq .Values.artifactory.node.podAntiAffinity.type "hard" }}
       affinity:
         podAntiAffinity:
@@ -254,7 +256,9 @@ spec:
               matchLabels:
                 app: {{ template "artifactory-ha.name" . }}
                 release: {{ .Release.Name }}
+                {{- if eq .Values.artifactory.service.pool "members" }}
                 role: {{ template "artifactory-ha.node.name" . }}
+                {{- end }}
     {{- end }}
     {{- with .Values.artifactory.node.tolerations }}
       tolerations:

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -244,9 +244,31 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- if .Values.artifactory.primary.affinity }}
     {{- with .Values.artifactory.primary.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- else if eq .Values.artifactory.primary.podAntiAffinity.type "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: {{ .Values.artifactory.primary.podAntiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  app: {{ template "artifactory-ha.name" . }}
+                  release: {{ .Release.Name }}
+    {{- else if eq .Values.artifactory.primary.podAntiAffinity.type "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: {{ .Values.artifactory.primary.podAntiAffinity.topologyKey }}
+            labelSelector:
+              matchLabels:
+                app: {{ template "artifactory-ha.name" . }}
+                release: {{ .Release.Name }}
     {{- end }}
     {{- with .Values.artifactory.primary.tolerations }}
       tolerations:

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -258,6 +258,12 @@ artifactory:
     tolerations: []
 
     affinity: {}
+    ## Only used if "affinity" is empty
+    podAntiAffinity:
+      ## Valid values are "soft" or "hard"; any other value indicates no anti-affinity
+      type: ""
+      topologyKey: "kubernetes.io/hostname"
+
   node:
     name: artifactory-ha-member
     persistence:


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow pod anti-affinity settings to include primary node 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #111 

