### PR TITLE
Support artifactory.preStartCommand for running command before entrypoint

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.3] - Nov 12, 2018
+* Support artifactory.preStartCommand for running command before entrypoint starts
+
 ## [0.7.2] - Nov 7, 2018
 * Support database.url parameter (DB_URL)
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.7.2
+version: 0.7.3
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -289,7 +289,7 @@ This can be done with the following parameters
 # Make sure your Artifactory Docker image has the MySQL database driver in it
 ...
 --set postgresql.enabled=false \
---set artifactory.postStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar" \
+--set artifactory.preStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar" \
 --set database.type=mysql \
 --set database.host=${DB_HOST} \
 --set database.port=${DB_PORT} \
@@ -353,6 +353,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.image.version`          | Container image tag                  | `.Chart.AppVersion`                        |
 | `artifactory.masterKey`           | Artifactory Master Key. Can be generated with `openssl rand -hex 32` |`FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF`|
 | `artifactory.masterKeySecretName` | Artifactory Master Key secret name                                   |                                                                  |
+| `artifactory.preStartCommand`                    | Command to run before entrypoint starts |                             |
+| `artifactory.postStartCommand`                   | Command to run after container starts   |                             |
 | `artifactory.license.secret` | Artifactory license secret name              |                                            |
 | `artifactory.license.dataKey`| Artifactory license secret data key          |                                            |
 | `artifactory.service.name`   | Artifactory service name to be set in Nginx configuration | `artifactory`                 |

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -289,7 +289,7 @@ This can be done with the following parameters
 # Make sure your Artifactory Docker image has the MySQL database driver in it
 ...
 --set postgresql.enabled=false \
---set artifactory.preStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar" \
+--set artifactory.preStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar" \
 --set database.type=mysql \
 --set database.host=${DB_HOST} \
 --set database.port=${DB_PORT} \

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -61,7 +61,11 @@ spec:
       {{- if .Values.postgresql.enabled }}
           until nc -z -w 2 {{ .Release.Name }}-postgresql {{ .Values.postgresql.service.port }} && echo database ok; do
       {{- else }}
+        {{- if and .Values.database.host .Values.database.port }}
           until nc -z -w 2 {{ .Values.database.host }} {{ .Values.database.port }} && echo database ok; do
+        {{- else }}
+          until true; do
+        {{- end }}
       {{- end }}
             sleep 2;
           done;
@@ -71,6 +75,15 @@ spec:
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
+      {{- if .Values.artifactory.preStartCommand }}
+        command:
+        - '/bin/sh'
+        - '-c'
+        - >
+          echo "Running custom preStartCommand command";
+          {{ .Values.artifactory.preStartCommand }};
+          /entrypoint-artifactory.sh
+      {{- end }}
         lifecycle:
           postStart:
             exec:

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -61,7 +61,11 @@ spec:
       {{- if .Values.postgresql.enabled }}
           until nc -z -w 2 {{ .Release.Name }}-postgresql {{ .Values.postgresql.service.port }} && echo database ok; do
       {{- else }}
+        {{- if and .Values.database.host .Values.database.port }}
           until nc -z -w 2 {{ .Values.database.host }} {{ .Values.database.port }} && echo database ok; do
+        {{- else }}
+          until true; do
+        {{- end }}
       {{- end }}
             sleep 2;
           done;
@@ -71,6 +75,15 @@ spec:
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
+      {{- if .Values.artifactory.preStartCommand }}
+        command:
+        - '/bin/sh'
+        - '-c'
+        - >
+          echo "Running custom preStartCommand command";
+          {{ .Values.artifactory.preStartCommand }};
+          /entrypoint-artifactory.sh
+      {{- end }}
         lifecycle:
           postStart:
             exec:

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -129,8 +129,10 @@ artifactory:
   ## Create configMap with artifactory.config.import.xml and security.import.xml and pass name of configMap in following parameter
   configMapName:
 
-  ## Extra postStart command to install JDBC driver for MySql/MariaDb/Oracle
-  # postStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar"
+  ## Extra pre-start command to install JDBC driver for MySql/MariaDb/Oracle
+  # preStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar"
+  ## Extra post-start command to run extra commands after container starts
+  # postStartCommand:
 
   membershipPort: 10017
   externalPort: 8081

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -130,7 +130,7 @@ artifactory:
   configMapName:
 
   ## Extra pre-start command to install JDBC driver for MySql/MariaDb/Oracle
-  # preStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar"
+  # preStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar"
   ## Extra post-start command to run extra commands after container starts
   # postStartCommand:
 

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.7.3] - Nov 12, 2018
+* Support artifactory.preStartCommand for running command before entrypoint starts
+
 ## [7.7.2] - Nov 7, 2018
 * Support database.url parameter (DB_URL)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.7.2
+version: 7.7.3
 appVersion: 6.5.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -167,7 +167,7 @@ This can be done with the following parameters
 # Make sure your Artifactory Docker image has the MySQL database driver in it
 ...
 --set postgresql.enabled=false \
---set artifactory.preStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar" \
+--set artifactory.preStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar" \
 --set database.type=mysql \
 --set database.host=${DB_HOST} \
 --set database.port=${DB_PORT} \

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -167,7 +167,7 @@ This can be done with the following parameters
 # Make sure your Artifactory Docker image has the MySQL database driver in it
 ...
 --set postgresql.enabled=false \
---set artifactory.postStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar" \
+--set artifactory.preStartCommand="curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar" \
 --set database.type=mysql \
 --set database.host=${DB_HOST} \
 --set database.port=${DB_PORT} \
@@ -241,6 +241,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 10 |
 | `artifactory.masterKey`                          | master.key to be used on bootstrap | `FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 | `artifactory.masterKeySecretName`                | Artifactory Master Key secret name |                                                                    |
+| `artifactory.preStartCommand`                    | Command to run before entrypoint starts |                             |
+| `artifactory.postStartCommand`                   | Command to run after container starts   |                             |
 | `artifactory.readinessProbe.enabled`             | would you like a readinessProbe to be enabled           |  `true`     |
 | `artifactory.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 60                        |
 | `artifactory.readinessProbe.periodSeconds`       | How often to perform the probe            | 10                        |

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -39,6 +39,7 @@ spec:
         runAsUser: {{ .Values.artifactory.uid }}
         fsGroup: {{ .Values.artifactory.uid }}
       initContainers:
+    {{- if .Values.artifactory.persistence.enabled }}
       - name: "remove-lost-found"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
@@ -49,6 +50,7 @@ spec:
         volumeMounts:
         - mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
           name: artifactory-volume
+    {{- end }}
       - name: "wait-for-db"
         image: "{{ .Values.initContainerImage }}"
         command:
@@ -72,6 +74,15 @@ spec:
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
+      {{- if .Values.artifactory.preStartCommand }}
+        command:
+        - '/bin/sh'
+        - '-c'
+        - >
+          echo "Running custom preStartCommand command";
+          {{ .Values.artifactory.preStartCommand }};
+          /entrypoint-artifactory.sh
+      {{- end }}
         lifecycle:
           postStart:
             exec:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -77,7 +77,7 @@ artifactory:
   # masterKeySecretName:
 
   ## Extra pre-start command to install JDBC driver for MySql/MariaDb/Oracle
-  # preStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar"
+  # preStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar"
   ## Extra post-start command to run extra commands after container starts
   # postStartCommand:
 

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -75,8 +75,11 @@ artifactory:
   masterKey: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
   ## Alternatively, you can use a pre-existing secret with a key called master-key by specifying masterKeySecretName
   # masterKeySecretName:
-  ## Extra postStart command to install JDBC driver for MySql/MariaDb/Oracle
-  # postStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar"
+
+  ## Extra pre-start command to install JDBC driver for MySql/MariaDb/Oracle
+  # preStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar && chown 1030:1030 /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar"
+  ## Extra post-start command to run extra commands after container starts
+  # postStartCommand:
 
   annotations: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add the ability to define `artifactory.preStartCommand` for running a command before the entrypoint, which can be used for downloading a custom DB driver to /opt/jfrog/artifactory/tomcat/lib

