### PR TITLE
Fix indent of nodeSelector, affinity and tolerations in the templates

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.4] - Nov 14, 2018
+* Fix indent of `nodeSelector`, `affinity` and `tolerations` in the templates
+
 ## [0.7.3] - Nov 11, 2018
 * Updated Xray version to 2.4.6
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.7.3
+version: 0.7.4
 appVersion: 2.4.6
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/templates/xray-analysis-deployment.yaml
+++ b/stable/xray/templates/xray-analysis-deployment.yaml
@@ -127,18 +127,6 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.analysis.resources | indent 10 }}
-        {{- with .Values.analysis.nodeSelector }}
-        nodeSelector:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.analysis.affinity }}
-        affinity:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.analysis.tolerations }}
-        tolerations:
-{{ toYaml . | indent 10 }}
-        {{- end }}
         readinessProbe:
           httpGet:
             path: /debug/pprof/
@@ -152,6 +140,18 @@ spec:
             port: {{ .Values.analysis.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10
+    {{- with .Values.analysis.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - name: data-volume
         emptyDir:

--- a/stable/xray/templates/xray-indexer-deployment.yaml
+++ b/stable/xray/templates/xray-indexer-deployment.yaml
@@ -127,18 +127,6 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.indexer.resources | indent 10 }}
-        {{- with .Values.indexer.nodeSelector }}
-        nodeSelector:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.indexer.affinity }}
-        affinity:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.indexer.tolerations }}
-        tolerations:
-{{ toYaml . | indent 10 }}
-        {{- end }}
         readinessProbe:
           httpGet:
             path: /debug/pprof/
@@ -152,6 +140,18 @@ spec:
             port: {{ .Values.indexer.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10
+    {{- with .Values.analysis.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - name: data-volume
         emptyDir:

--- a/stable/xray/templates/xray-persist-deployment.yaml
+++ b/stable/xray/templates/xray-persist-deployment.yaml
@@ -127,18 +127,6 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.persist.resources | indent 10 }}
-        {{- with .Values.persist.nodeSelector }}
-        nodeSelector:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.persist.affinity }}
-        affinity:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.persist.tolerations }}
-        tolerations:
-{{ toYaml . | indent 10 }}
-        {{- end }}
         readinessProbe:
           httpGet:
             path: /debug/pprof/
@@ -152,6 +140,18 @@ spec:
             port: {{ .Values.persist.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10
+    {{- with .Values.analysis.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - name: data-volume
         emptyDir:

--- a/stable/xray/templates/xray-server-deployment.yaml
+++ b/stable/xray/templates/xray-server-deployment.yaml
@@ -127,18 +127,6 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.server.resources | indent 10 }}
-        {{- with .Values.server.nodeSelector }}
-        nodeSelector:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.server.affinity }}
-        affinity:
-{{ toYaml . | indent 10 }}
-        {{- end }}
-        {{- with .Values.server.tolerations }}
-        tolerations:
-{{ toYaml . | indent 10 }}
-        {{- end }}
         readinessProbe:
           httpGet:
             path: /
@@ -152,6 +140,18 @@ spec:
             port: {{ .Values.server.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10
+    {{- with .Values.analysis.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.analysis.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - name: data-volume
         emptyDir:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix indent of nodeSelector, affinity and tolerations in the templates

**Special notes for your reviewer**:
Try setting nodeSelector, affinity or tolerations and see it takes affect.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changelog.md updated
- [x] Variables and other changes are documented in the README.md
