### PR TITLE
Remove -Dartifactory.locking.provider.type=db. This is already default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 #### PR Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 - [ ] Chart Version bumped
-- [ ] Changelog.md updated
+- [ ] CHANGELOG.md updated
 - [ ] Variables and other changes are documented in the README.md
 
 <!--

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.12] - Dec 2, 2018
+* Remove Java option "-Dartifactory.locking.provider.type=db". This is already the default setting.
+
 ## [0.7.11] - Nov 30, 2018
 * Updated Artifactory version to 6.5.9
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.7.11
+version: 0.7.12
 appVersion: 6.5.9
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -401,10 +401,10 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.awsS3.path`                | AWS S3 path in bucket                  | `artifactory-ha/filestore`   |
 | `artifactory.persistence.awsS3.refreshCredentials`  | AWS S3 renew credentials on expiration | `true`                       |
 | `artifactory.persistence.awsS3.testConnection`      | AWS S3 test connection on start up     | `false`                      |
-| `artifactory.javaOpts.other` | Artifactory extra java options (for all nodes) | `-Dartifactory.locking.provider.type=db` |
-| `artifactory.replicator.enabled`            | Enable Artifactory Replicator | `false`                                    |
-| `artifactory.distributionCerts`            | Name of ConfigMap for Artifactory Distribution Certificate  |               |
-| `artifactory.replicator.publicUrl`            | Artifactory Replicator Public URL |                                      |
+| `artifactory.javaOpts.other`                        | Artifactory additional java options (for all nodes) |                 |
+| `artifactory.replicator.enabled`                    | Enable Artifactory Replicator          | `false`                      |
+| `artifactory.distributionCerts`                 | Name of ConfigMap for Artifactory Distribution Certificate  |          |
+| `artifactory.replicator.publicUrl`              | Artifactory Replicator Public URL |                                    |
 | `artifactory.primary.resources.requests.memory` | Artifactory primary node initial memory request  |                     |
 | `artifactory.primary.resources.requests.cpu`    | Artifactory primary node initial cpu request     |                     |
 | `artifactory.primary.resources.limits.memory`   | Artifactory primary node memory limit            |                     |

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -227,8 +227,8 @@ artifactory:
 
   ## The following Java options are passed to the java process running Artifactory.
   ## This will be passed to all cluster members. Primary and member nodes.
-  javaOpts:
-    other: "-Dartifactory.locking.provider.type=db"
+  javaOpts: {}
+    # other: ""
   ## Artifactory Replicator is available only for Enterprise Plus
   replicator:
     enabled: false
@@ -260,7 +260,7 @@ artifactory:
     javaOpts: {}
     #  xms: "1g"
     #  xmx: "2g"
-    #  other:
+    #  other: ""
     nodeSelector: {}
 
     tolerations: []
@@ -293,7 +293,7 @@ artifactory:
     javaOpts: {}
     #  xms: "1g"
     #  xmx: "2g"
-    #  other:
+    #  other: ""
     nodeSelector: {}
 
     tolerations: []


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changelog.md updated
- [x] Variables and other changes are documented in the README.md

Remove java option `-Dartifactory.locking.provider.type=db`. This is already default setting.
