### PR TITLE
Add support for Azure Blob Storage binary provider

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.8.7] - Jan 15, 2018
+* Add support for Azure Blob Storage Binary provider
+
 ## [0.8.6] - Jan 13, 2019
 * Fix documentation about nginx group id
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.8.6
+version: 0.8.7
 appVersion: 6.6.5
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -112,7 +112,7 @@ To use an NFS server as your cluster's storage, you need to
 ```
 
 #### Google Storage
-To use a Google Storage bucket as the cluster's filestore
+To use a Google Storage bucket as the cluster's filestore. See [Google Storage Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-GoogleStorageBinaryProvider)
 - Pass Google Storage parameters to `helm install` and `helm upgrade`
 ```bash
 ...
@@ -123,7 +123,7 @@ To use a Google Storage bucket as the cluster's filestore
 ```
 
 #### AWS S3
-To use an AWS S3 bucket as the cluster's filestore
+To use an AWS S3 bucket as the cluster's filestore. See [S3 Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-S3BinaryProvider)
 - Pass AWS S3 parameters to `helm install` and `helm upgrade`
 ```bash
 ...
@@ -144,6 +144,19 @@ To use an AWS S3 bucket as the cluster's filestore
 ...
 ```
 **NOTE:** Make sure S3 `endpoint` and `region` match. See [AWS documentation on endpoint](https://docs.aws.amazon.com/general/latest/gr/rande.html)
+
+#### Microsoft Azure Blob Storage
+To use Azure Blob Storage as the cluster's filestore. See [Azure Blob Storage Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-AzureBlobStorageBinaryProvider)
+- Pass Azure Blob Storage parameters to `helm install` and `helm upgrade`
+```bash
+...
+--set artifactory.persistence.type=azure-blob \
+--set artifactory.persistence.azureBlob.accountName=${AZURE_ACCOUNT_NAME} \
+--set artifactory.persistence.azureBlob.accountKey=${AZURE_ACCOUNT_KEY} \
+--set artifactory.persistence.azureBlob.endpoint=${AZURE_ENDPOINT} \
+--set artifactory.persistence.azureBlob.containerName=${AZURE_CONTAINER_NAME} \
+...
+```
 
 ### Create a unique Master Key
 Artifactory HA cluster requires a unique master key. By default the chart has one set in values.yaml (`artifactory.masterKey`).
@@ -384,6 +397,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.nfs.dataDir`       | HA data directory                    | `/var/opt/jfrog/artifactory-ha`     |
 | `artifactory.persistence.nfs.backupDir`     | HA backup directory                  | `/var/opt/jfrog/artifactory-backup` |
 | `artifactory.persistence.nfs.capacity`      | NFS PVC size                         | `200Gi`                             |
+| `artifactory.persistence.eventual.numberOfThreads`  | Eventual number of threads   | `10`                                |
 | `artifactory.persistence.googleStorage.bucketName`  | Google Storage bucket name          | `artifactory-ha`             |
 | `artifactory.persistence.googleStorage.identity`    | Google Storage service account id   |                              |
 | `artifactory.persistence.googleStorage.credential`  | Google Storage service account key  |                              |
@@ -398,8 +412,13 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.awsS3.path`                | AWS S3 path in bucket                  | `artifactory-ha/filestore`   |
 | `artifactory.persistence.awsS3.refreshCredentials`  | AWS S3 renew credentials on expiration | `true` (When roleName is used, this parameter will be set to true) |
 | `artifactory.persistence.awsS3.testConnection`      | AWS S3 test connection on start up     | `false`                      |
-| `artifactory.javaOpts.other`                        | Artifactory additional java options (for all nodes) |                 |
-| `artifactory.replicator.enabled`                    | Enable Artifactory Replicator          | `false`                      |
+| `artifactory.persistence.azureBlob.accountName`     | Azure Blob Storage account name        | ``                        |
+| `artifactory.persistence.azureBlob.accountKey`      | Azure Blob Storage account key         | ``                        |
+| `artifactory.persistence.azureBlob.endpoint`        | Azure Blob Storage endpoint            | ``                        |
+| `artifactory.persistence.azureBlob.containerName`   | Azure Blob Storage container name      | ``                        |
+| `artifactory.persistence.azureBlob.testConnection`  | Azure Blob Storage test connection     | `false`                   |
+| `artifactory.javaOpts.other`                        | Artifactory additional java options (for all nodes) |              |
+| `artifactory.replicator.enabled`                    | Enable Artifactory Replicator          | `false`                   |
 | `artifactory.replicator.publicUrl`              | Artifactory Replicator Public URL |                                    |
 | `artifactory.primary.resources.requests.memory` | Artifactory primary node initial memory request  |                     |
 | `artifactory.primary.resources.requests.cpu`    | Artifactory primary node initial cpu request     |                     |

--- a/stable/artifactory-ha/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory-ha/templates/artifactory-binarystore.yaml
@@ -158,3 +158,35 @@ data:
         </provider>
     </config>
 {{- end }}
+
+{{- if eq .Values.artifactory.persistence.type "azure-blob" }}
+    <!-- Azure Blob Storage -->
+    <config version="2">
+      <chain>
+        <provider id="cache-fs" type="cache-fs">
+          <provider id="eventual" type="eventual">
+            <provider id="retry" type="retry">
+              <provider id="azure-blob-storage" type="azure-blob-storage"/>
+            </provider>
+          </provider>
+        </provider>
+      </chain>
+
+      <!-- Set max cache-fs size -->
+      <provider id="cache-fs" type="cache-fs">
+        <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+      </provider>
+
+      <provider type="eventual" id="eventual">
+        <numberOfThreads>{{ .Values.artifactory.persistence.eventual.numberOfThreads }}</numberOfThreads>
+      </provider>
+
+      <provider id="azure-blob-storage" type="azure-blob-storage">
+        <accountName>{{ .Values.artifactory.persistence.azureBlob.accountName }}</accountName>
+        <accountKey>{{ .Values.artifactory.persistence.azureBlob.accountKey }}</accountKey>
+        <endpoint>{{ .Values.artifactory.persistence.azureBlob.endpoint }}</endpoint>
+        <containerName>{{ .Values.artifactory.persistence.azureBlob.containerName }}</containerName>
+        <testConnection>{{ .Values.artifactory.persistence.azureBlob.testConnection }}</testConnection>
+      </provider>
+    </config>
+{{- end }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -183,6 +183,8 @@ artifactory:
     accessMode: ReadWriteOnce
     size: 200Gi
     maxCacheSize: 50000000000
+    eventual:
+      numberOfThreads: 10
     ## artifactory data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -198,6 +200,7 @@ artifactory:
     ## nfs
     ## google-storage
     ## aws-s3
+    ## azure-blob
     type: file-system
 
     ## For artifactory.persistence.type nfs
@@ -235,6 +238,13 @@ artifactory:
       ## Additional properties to set on the s3 provider
       properties: {}
       #  httpclient.max-connections: 100
+    ## For artifactory.persistence.type azure-blob
+    azureBlob:
+      accountName:
+      accountKey:
+      endpoint:
+      containerName:
+      testConnection: false
   service:
     name: artifactory
     type: ClusterIP


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Add support for using [Azure Blob Storage](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-AzureBlobStorageClusterBinaryProvider) as binary provider.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #125 



