### PR TITLE
Add support for the AWS S3 IAM role name setup

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.15] - Dec 9, 2018
+* AWS S3 add `roleName` for using IAM role
+
 ## [0.7.14] - Dec 6, 2018
 * AWS S3 `identity` and `credential` are now added only if have a value to allow using IAM role 
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.7.14
+version: 0.7.15
 appVersion: 6.5.9
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -140,6 +140,7 @@ To use an AWS S3 bucket as the cluster's filestore
 --set artifactory.persistence.type=aws-s3 \
 --set artifactory.persistence.awsS3.endpoint=${AWS_S3_ENDPOINT} \
 --set artifactory.persistence.awsS3.region=${AWS_REGION} \
+--set artifactory.persistence.awsS3.roleName=${AWS_ROLE_NAME} \
 ...
 ```
 **NOTE:** Make sure S3 `endpoint` and `region` match. See [AWS documentation on endpoint](https://docs.aws.amazon.com/general/latest/gr/rande.html)
@@ -388,11 +389,12 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.awsS3.bucketName`          | AWS S3 bucket name                     | `artifactory-ha`             |
 | `artifactory.persistence.awsS3.endpoint`            | AWS S3 bucket endpoint                 | See https://docs.aws.amazon.com/general/latest/gr/rande.html |
 | `artifactory.persistence.awsS3.region`              | AWS S3 bucket region                   |                              |
+| `artifactory.persistence.awsS3.roleName`            | AWS S3 IAM role name                   |                             |
 | `artifactory.persistence.awsS3.identity`            | AWS S3 AWS_ACCESS_KEY_ID               |                              |
 | `artifactory.persistence.awsS3.credential`          | AWS S3 AWS_SECRET_ACCESS_KEY           |                              |
 | `artifactory.persistence.awsS3.properties`          | AWS S3 additional properties           |                              |
 | `artifactory.persistence.awsS3.path`                | AWS S3 path in bucket                  | `artifactory-ha/filestore`   |
-| `artifactory.persistence.awsS3.refreshCredentials`  | AWS S3 renew credentials on expiration | `true`                       |
+| `artifactory.persistence.awsS3.refreshCredentials`  | AWS S3 renew credentials on expiration | `true` (When roleName is used, this parameter will be set to true) |
 | `artifactory.persistence.awsS3.testConnection`      | AWS S3 test connection on start up     | `false`                      |
 | `artifactory.javaOpts.other`                        | Artifactory additional java options (for all nodes) |                 |
 | `artifactory.replicator.enabled`                    | Enable Artifactory Replicator          | `false`                      |

--- a/stable/artifactory-ha/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory-ha/templates/artifactory-binarystore.yaml
@@ -135,7 +135,12 @@ data:
 
         <provider id="s3" type="s3">
             <endpoint>{{ .Values.artifactory.persistence.awsS3.endpoint }}</endpoint>
+        {{- if .Values.artifactory.persistence.awsS3.roleName }}
+            <roleName>{{ .Values.artifactory.persistence.awsS3.roleName }}</roleName>
+            <refreshCredentials>true</refreshCredentials>
+        {{- else }}
             <refreshCredentials>{{ .Values.artifactory.persistence.awsS3.refreshCredentials }}</refreshCredentials>
+        {{- end }}
             <testConnection>{{ .Values.artifactory.persistence.awsS3.testConnection }}</testConnection>
             <httpsOnly>true</httpsOnly>
             <region>{{ .Values.artifactory.persistence.awsS3.region }}</region>

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -208,6 +208,7 @@ artifactory:
       bucketName: "artifactory-ha-aws"
       endpoint:
       region:
+      roleName:
       identity:
       credential:
       path: "artifactory-ha/filestore"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Support the **roleName** property for AWS S3 binary provider for using IAM roles and not identity.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #142 

**Special notes for your reviewer**:

