### PR TITLE
Xray server support GKE ingress controller with health probes - fix

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.8] - Dec 18, 2018
+* Fix for 0.7.7 (Improve server health probes to support GKE ingress controller. Fixes https://github.com/jfrog/charts/issues/149)
+
 ## [0.7.7] - Dec 18, 2018
 * Improve server health probes to support GKE ingress controller. Fixes https://github.com/jfrog/charts/issues/149
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.7.7
+version: 0.7.8
 appVersion: 2.4.6
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/templates/xray-server-deployment.yaml
+++ b/stable/xray/templates/xray-server-deployment.yaml
@@ -135,14 +135,14 @@ spec:
 {{ toYaml .Values.server.resources | indent 10 }}
         readinessProbe:
           httpGet:
-            path: /web
+            path: /web/
             port: {{ .Values.server.internalPort }}
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 10
         livenessProbe:
           httpGet:
-            path: /web
+            path: /web/
             port: {{ .Values.server.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

Fix previous version (0.7.7). Was missing a training `/` for the probes. Now set to `/web/`.