### PR TITLE
Set correct path to replicator.yaml

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.8.2] - Dec 28, 2018
+* Fix location `replicator.yaml` is copied to
+
 ## [0.8.1] - Dec 27, 2018
 * Updated Artifactory version to 6.6.1
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.8.1
+version: 0.8.2
 appVersion: 6.6.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -93,8 +93,8 @@ spec:
               - '-c'
               - >
                 {{- if .Values.artifactory.replicator.enabled }}
-                mkdir -p {{ .Values.artifactory.persistence.mountPath }}/replicator/etc;
-                cp -fv /tmp/replicator/replicator.yaml {{ .Values.artifactory.persistence.mountPath }}/replicator/etc/replicator.yaml;
+                mkdir -p /opt/jfrog/artifactory/replicator/etc;
+                cp -fv /tmp/replicator/replicator.yaml /opt/jfrog/artifactory/replicator/etc/replicator.yaml;
                 {{- end }}
                 {{- if .Values.artifactory.postStartCommand }}
                 {{ .Values.artifactory.postStartCommand }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -96,8 +96,8 @@ spec:
                 cp -Lrf /bootstrap/* /artifactory_extra_conf/;
                 {{- end }}
                 {{- if .Values.artifactory.replicator.enabled }}
-                mkdir -p {{ .Values.artifactory.persistence.mountPath }}/replicator/etc;
-                cp -fv /tmp/replicator/replicator.yaml {{ .Values.artifactory.persistence.mountPath }}/replicator/etc/replicator.yaml;
+                mkdir -p /opt/jfrog/artifactory/replicator/etc;
+                cp -fv /tmp/replicator/replicator.yaml /opt/jfrog/artifactory/replicator/etc/replicator.yaml;
                 {{- end }}
                 {{- if .Values.artifactory.postStartCommand }}
                 {{ .Values.artifactory.postStartCommand }}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.8.2] - Dec 28, 2018
+* Fix location `replicator.yaml` is copied to
+
 ## [7.8.1] - Dec 27, 2018
 * Updated Artifactory version to 6.6.1
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.8.1
+version: 7.8.2
 appVersion: 6.6.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -94,8 +94,8 @@ spec:
                 cp -Lrf /bootstrap/* /artifactory_extra_conf/;
                 {{- end }}
                 {{- if .Values.artifactory.replicator.enabled }}
-                mkdir -p {{ .Values.artifactory.persistence.mountPath }}/replicator/etc;
-                cp -fv /tmp/replicator/replicator.yaml {{ .Values.artifactory.persistence.mountPath }}/replicator/etc/replicator.yaml;
+                mkdir -p /opt/jfrog/artifactory/replicator/etc;
+                cp -fv /tmp/replicator/replicator.yaml /opt/jfrog/artifactory/replicator/etc/replicator.yaml;
                 {{- end }}
                 {{- if .Values.artifactory.postStartCommand }}
                 {{ .Values.artifactory.postStartCommand }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

**What this PR does / why we need it**:
Change the location we copy the `replicator.yaml` to so it will actually be picked up by replicator process.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
This is a temporary fix as the Docker image needs to be updated to create symlink `/opt/jfrog/artifactory/replicator` -> `/var/opt/jfrog/artifactory/replicator/`.
Config and data need to be persisted. Application and data+config should be separated.
