### PR TITLE
Fix typo with nginx configuration options

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.8.6] - Jan 13, 2019
+* Fix documentation about nginx group id
+
 ## [0.8.5] - Jan 13, 2019
 * Updated Artifactory version to 6.6.5
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.8.5
+version: 0.8.6
 appVersion: 6.6.5
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -427,7 +427,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `nginx.name`                | Nginx name                        | `nginx`                                                |
 | `nginx.replicaCount`        | Nginx replica count               | `1`                                                    |
 | `nginx.uid`                 | Nginx User Id                     | `104`                                                  |
-| `nginx.git`                 | Nginx Group Id                    | `107`                                                  |
+| `nginx.gid`                 | Nginx Group Id                    | `107`                                                  |
 | `nginx.image.repository`    | Container image                   | `docker.bintray.io/jfrog/nginx-artifactory-pro`        |
 | `nginx.image.version`       | Container version                 | `.Chart.AppVersion`                                    |
 | `nginx.image.pullPolicy`    | Container pull policy             | `IfNotPresent`                                         |

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.8.6] - Jan 13, 2019
+* Fix documentation about nginx group id
+
 ## [7.8.5] - Jan 13, 2019
 * Updated Artifactory version to 6.6.5
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.8.5
+version: 7.8.6
 appVersion: 6.6.5
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -259,7 +259,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `nginx.enabled` | Deploy nginx server | `true`                                                                           |
 | `nginx.replicaCount` | Nginx replica count | `1`                                                                         |
 | `nginx.uid`                 | Nginx User Id                     | `104`                                                  |
-| `nginx.git`                 | Nginx Group Id                    | `107`                                                  |
+| `nginx.gid`                 | Nginx Group Id                    | `107`                                                  |
 | `nginx.image.repository`    | Container image                   | `docker.bintray.io/jfrog/nginx-artifactory-pro`        |
 | `nginx.image.version`       | Container tag                     | `.Chart.AppVersion`                                    |
 | `nginx.image.pullPolicy`    | Container pull policy                   | `IfNotPresent`                                   |


### PR DESCRIPTION
**What this PR does / why we need it**:

This is purely a documentation change and does not affect the functionality of the chart.

The README.md references a configuration option as `nginx.git` for group ID.
This option should be `nginx.gid` instead. This change corrects that typo.