### PR TITLE
Make artifactory.replicator.publicUrl required when the replicator is…

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.8.4] - Jan 8, 2019
+* Make artifactory.replicator.publicUrl required when the replicator is enabled
+
 ## [0.8.3] - Jan 1, 2019
 * Updated Artifactory version to 6.6.3
 * Add support for `artifactory.extraEnvironmentVariables` to pass more environment variables to Artifactory

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.8.3
+version: 0.8.4
 appVersion: 6.6.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -37,8 +37,8 @@ helm install --name artifactory-ha jfrog/artifactory-ha
 
 ### Deploying Artifactory with replicator enabled
 ```bash
-## Artifactory replicator is disabled by default. To enable it use the following:
-helm install --name artifactory --set artifactory.replicator.enabled=true jfrog/artifactory-ha
+## Artifactory replicator is disabled by default. When the replicator is enabled, the replicator.publicUrl parameter is required. To enable it use the following:
+helm install --name artifactory --set artifactory.replicator.enabled=true --set artifactory.replicator.publicUrl=<artifactory_url>:<replicator_port> jfrog/artifactory-ha
 ```
 
 ### Accessing Artifactory

--- a/stable/artifactory-ha/templates/replicator-configmap.yaml
+++ b/stable/artifactory-ha/templates/replicator-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     release: {{ .Release.Name }}
 data:
   replicator.yaml: |-
-    externalUrl: {{ .Values.artifactory.replicator.publicUrl }}
+    externalUrl: {{ required "artifactory.replicator.publicUrl is required when artifactory.replicator.enabled is true" .Values.artifactory.replicator.publicUrl }}
     internalUrl: http://localhost:6061
     listenPort: 6061
 {{- end -}}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.8.4] - Jan 8, 2019
+* Make artifactory.replicator.publicUrl required when the replicator is enabled 
+
 ## [7.8.3] - Jan 1, 2019
 * Updated Artifactory version to 6.6.3
 * Add support for `artifactory.extraEnvironmentVariables` to pass more environment variables to Artifactory

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.8.3
+version: 7.8.4
 appVersion: 6.6.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -35,8 +35,8 @@ helm install --name artifactory --set artifactory.image.repository=docker.bintra
 
 ### Deploying Artifactory with replicator enabled
 ```bash
-## Artifactory replicator is disabled by default. To enable it use the following:
-helm install --name artifactory --set artifactory.replicator.enabled=true jfrog/artifactory
+## Artifactory replicator is disabled by default. When the replicator is enabled, the replicator.publicUrl parameter is required. To enable it use the following:
+helm install --name artifactory --set artifactory.replicator.enabled=true --set artifactory.replicator.publicUrl=<artifactory_url>:<replicator_port> jfrog/artifactory
 ```
 
 ### Accessing Artifactory

--- a/stable/artifactory/templates/replicator-configmap.yaml
+++ b/stable/artifactory/templates/replicator-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     release: {{ .Release.Name }}
 data:
   replicator.yaml: |
-    externalUrl: {{ .Values.artifactory.replicator.publicUrl }}
+    externalUrl: {{ required "artifactory.replicator.publicUrl is required when artifactory.replicator.enabled is true" .Values.artifactory.replicator.publicUrl }}
     internalUrl: http://localhost:6061
     listenPort: 6061
 {{- end -}}


### PR DESCRIPTION
… enabled

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--

**What this PR does / why we need it**:
Currently, when artifactory.replicator.enabled is set to true, the artifactory.replicator.publicUrl is required for proper configuration of the replicator but when running helm install there is no indication of that and its hard to know that the parameter is missing. This will fail the chart installation/upgrade when the replicator is enabled but the public url is not set.
