### PR TITLE
Missing doc about setting 'mongodb.enabled=false' with external MongoDB

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.8.2] - Jan 24, 2019
+* Added missing documentation about using `mongodb.enabled=false` when using external MongoDB
+
 ## [0.8.1] - Jan 22, 2019
 * Added support for `common.customInitContainers` to create custom init containers
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.8.1
+version: 0.8.2
 appVersion: 2.6.0
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -90,7 +90,7 @@ There is an option to use external database services (MongoDB or PostgreSQL) for
 #### MongoDB
 To use an external **MongoDB**, You need to set Xray **MongoDB** connection URL.
 
-For this, pass the parameter: `global.mongoUrl=${XRAY_MONGODB_CONN_URL}`.
+For this, pass the parameter: `mongodb.enabled=false` and `global.mongoUrl=${XRAY_MONGODB_CONN_URL}`.
 
 **IMPORTANT:** Make sure the DB is already created before deploying Xray services
 ```bash
@@ -103,7 +103,10 @@ For this, pass the parameter: `global.mongoUrl=${XRAY_MONGODB_CONN_URL}`.
 # MongoDB password: password1_X
 
 export XRAY_MONGODB_CONN_URL='mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@custom-mongodb.local:27017/?authSource=${MONGODB_DATABASE}\&authMechanism=SCRAM-SHA-1'
-helm install -n xray --set global.mongoUrl=${XRAY_MONGODB_CONN_URL} jfrog/xray
+helm install -n xray \
+    --set mongodb.enabled=false \
+    --set global.mongoUrl=${XRAY_MONGODB_CONN_URL} \
+    jfrog/xray
 ```
 
 #### PostgreSQL
@@ -122,7 +125,10 @@ For this, pass the parameters: `postgresql.enabled=false` and `global.postgresql
 # PostgreSQL password: password2_X
 
 export XRAY_POSTGRESQL_CONN_URL='postgres://${POSTGRESQL_USER}:${POSTGRESQL_PASSWORD}@custom-postgresql.local:5432/${POSTGRESQL_DATABASE}?sslmode=disable'
-helm install -n xray --set postgresql.enabled=false,global.postgresqlUrl=${XRAY_POSTGRESQL_CONN_URL} jfrog/xray
+helm install -n xray \
+    --set postgresql.enabled=false \
+    --set global.postgresqlUrl=${XRAY_POSTGRESQL_CONN_URL} \
+    jfrog/xray
 ```
 
 ### Custom init containers


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Added missing note about setting `mongodb.enabled=false` when using external MongoDB.

