### PR TITLE
Add 0.5G memory buffer for java services

### DIFF
--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.7.3] - Jan 31, 2019
+* Add 0.5G to all memory limits for java services to be higher than java xmx value
+
 ## [0.7.2] - Jan 23, 2019
 * Added support for `missionControl.customInitContainers` to create custom init containers
 

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 description: A Helm chart for JFrog Mission Control
-version: 0.7.2
+version: 0.7.3
 appVersion: 3.3.2
 home: https://jfrog.com/mission-control/
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png

--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -105,7 +105,7 @@ The following table lists the configurable parameters of the distribution chart 
 | `missionControl.name`                        | Mission Control name                            | `mission-control`                     |
 | `missionControl.replicaCount`                | Mission Control replica count                   | `1`                                   |
 | `missionControl.image`                       | Container image                                 | `docker.jfrog.io/jfrog/mission-control`     |
-| `missionControl.version`                     | Container image tag                             | `3.1.2`                               |
+| `missionControl.version`                     | Container image tag                             | `.Chart.AppVersion`                               |
 | `missionControl.customInitContainers`        | Custom init containers                          | ``                                    |
 | `missionControl.service.type`                | Mission Control service type                    | `LoadBalancer`                        |
 | `missionControl.externalPort`                | Mission Control service external port           | `80`                                  |
@@ -123,7 +123,7 @@ The following table lists the configurable parameters of the distribution chart 
 | `insightServer.name`                         | Insight Server name                             | `insight-server`                      |
 | `insightServer.replicaCount`                 | Insight Server replica count                    | `1`                                   |
 | `insightServer.image`                        | Container image                                 | `docker.jfrog.io/jfrog/insight-server`|
-| `insightServer.version`                      | Container image tag                             | `3.1.2`                               |
+| `insightServer.version`                      | Container image tag                             | `.Chart.AppVersion`                               |
 | `insightServer.service.type`                 | Insight Server service type                     | `ClusterIP`                           |
 | `insightServer.externalHttpPort`             | Insight Server service external port            | `8082`                                |
 | `insightServer.internalHttpPort`             | Insight Server service internal port            | `8082`                                |
@@ -131,7 +131,7 @@ The following table lists the configurable parameters of the distribution chart 
 | `insightScheduler.name`                      | Insight Scheduler name                          | `insight-scheduler`                   |
 | `insightScheduler.replicaCount`              | Insight Scheduler replica count                 | `1`                                   |
 | `insightScheduler.image`                     | Container image                                 | `docker.jfrog.io/jfrog/insight-scheduler`  |
-| `insightScheduler.version`                   | Container image tag                             | `3.1.2`                               |
+| `insightScheduler.version`                   | Container image tag                             | `.Chart.AppVersion`                               |
 | `insightScheduler.service.type`              | Insight Scheduler service type                  | `ClusterIP`                           |
 | `insightScheduler.externalPort`              | Insight Scheduler service external port         | `8080`                                |
 | `insightScheduler.internalPort`              | Insight Scheduler service internal port         | `8080`                                |
@@ -141,7 +141,7 @@ The following table lists the configurable parameters of the distribution chart 
 | `insightExecutor.name`                       | Insight Executor name                           | `insight-scheduler`                   |
 | `insightExecutor.replicaCount`               | Insight Executor replica count                  | `1`                                   |
 | `insightExecutor.image`                      | Container image                                 | `docker.jfrog.io/jfrog/insight-executor`   |
-| `insightExecutor.version`                    | Container image tag                             | `3.1.2`                               |
+| `insightExecutor.version`                    | Container image tag                             | `.Chart.AppVersion`                               |
 | `insightExecutor.service.type`               | Insight Executor service type                   | `ClusterIP`                           |
 | `insightExecutor.externalPort`               | Insight Executor service external port          | `8080`                                |
 | `insightExecutor.internalPort`               | Insight Executor service internal port          | `8080`                                |

--- a/stable/mission-control/values.yaml
+++ b/stable/mission-control/values.yaml
@@ -171,7 +171,7 @@ missionControl:
     # storageClass: "-"
 
   ## Control Java options (JAVA_OPTIONS)
-  ## IMPORTANT: keep javaOpts.xmx no higher than resources.limits.memory
+  ## IMPORTANT: keep resources.limits.memory higher than javaOpts.xmx by 0.5G
   javaOpts:
     other: "-server -XX:+UseG1GC -Dfile.encoding=UTF8"
   #  xms: "2g"
@@ -181,7 +181,7 @@ missionControl:
   #    memory: "2Gi"
   #    cpu: "100m"
   #  limits:
-  #    memory: "3Gi"
+  #    memory: "3.5Gi"
   #    cpu: "1"
   nodeSelector: {}
 
@@ -274,7 +274,7 @@ insightScheduler:
   internalPort: 8080
 
   ## Control Java options (JFMC_EXTRA_JAVA_OPTS)
-  ## IMPORTANT: keep javaOpts.xmx no higher than resources.limits.memory
+  ## IMPORTANT: keep resources.limits.memory higher than javaOpts.xmx by 0.5G
   javaOpts: {}
   #  other:
   #  xms: "500m"
@@ -284,7 +284,7 @@ insightScheduler:
   #    memory: "500Mi"
   #    cpu: "100m"
   #  limits:
-  #    memory: "3Gi"
+  #    memory: "3.5Gi"
   #    cpu: "1"
   nodeSelector: {}
 
@@ -324,7 +324,7 @@ insightExecutor:
   internalPort: 8080
 
   ## Control Java options (JFMC_EXTRA_JAVA_OPTS)
-  ## IMPORTANT: keep javaOpts.xmx no higher than resources.limits.memory
+  ## IMPORTANT: keep resources.limits.memory higher than javaOpts.xmx by 0.5G
   javaOpts: {}
   #  other:
   #  xms: "500m"
@@ -334,7 +334,7 @@ insightExecutor:
   #    memory: "500Mi"
   #    cpu: "100m"
   #  limits:
-  #    memory: "3Gi"
+  #    memory: "3.5Gi"
   #    cpu: "1"
   nodeSelector: {}
 


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Avoid OOMKill to java pods by adding 0.5G memory buffer in example resources allocation.
