### PR TITLE
Fixes location of terminationGracePeriodSeconds

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.9.5] - Feb 6, 2019
+* Fix support for customizing statefulset `terminationGracePeriodSeconds`
+
 ## [0.9.4] - Feb 5, 2019
 * Add support for customizing statefulset `terminationGracePeriodSeconds`
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.9.4
+version: 0.9.5
 appVersion: 6.7.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -32,6 +32,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "artifactory-ha.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.artifactory.terminationGracePeriodSeconds}}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
@@ -227,7 +228,6 @@ spec:
       {{- end }}
         resources:
 {{ toYaml .Values.artifactory.node.resources | indent 10 }}
-        terminationGracePeriodSeconds: {{ .Values.artifactory.terminationGracePeriodSeconds}}
         {{- if .Values.artifactory.readinessProbe.enabled }}
         readinessProbe:
           httpGet:

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -32,6 +32,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "artifactory-ha.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.artifactory.terminationGracePeriodSeconds }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
@@ -239,7 +240,6 @@ spec:
       {{- end }}
         resources:
 {{ toYaml .Values.artifactory.primary.resources | indent 10 }}
-        terminationGracePeriodSeconds: {{ .Values.artifactory.terminationGracePeriodSeconds }}
         {{- if .Values.artifactory.readinessProbe.enabled }}
         readinessProbe:
           httpGet:

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.9.4] - Feb 6, 2019
+* Fix support for customizing statefulset `terminationGracePeriodSeconds`
+
 ## [7.9.3] - Feb 5, 2019
 * Add instructions on how to deploy Artifactory with embedded Derby database
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.9.3
+version: 7.9.4
 appVersion: 6.7.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -31,6 +31,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "artifactory.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.artifactory.terminationGracePeriodSeconds }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
@@ -210,7 +211,6 @@ spec:
       {{- end }}
         resources:
 {{ toYaml .Values.artifactory.resources | indent 10 }}
-        terminationGracePeriodSeconds: {{ .Values.artifactory.terminationGracePeriodSeconds }}
       {{- if .Values.artifactory.readinessProbe.enabled }}
         readinessProbe:
           httpGet:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
`terminationGracePeriodSeconds` wasn't set in the correct location, so it wasn't being recognized by the pod.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

