### PR TITLE
[stable/artifactory] Binarystore configuration for artifactory chart

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.11.0] - Feb 20, 2019
+* Added support for enterprise storage
+
 ## [7.10.2] - Feb 19, 2019
 * Updated Artifactory version to 6.8.2
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.0.0
+version: 7.11.0
 appVersion: 6.8.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.10.2
+version: 8.0.0
 appVersion: 6.8.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -82,6 +82,75 @@ helm install --name artifactory \
 ```
 Get more details on configuring Artifactory in the [official documentation](https://www.jfrog.com/confluence/).
 
+### Artifactory storage
+When using an enterprise license. Artifactory supports a wide range of storage back ends. You can see more details on [Artifactory HA storage options](https://www.jfrog.com/confluence/display/RTF/HA+Installation+and+Setup#HAInstallationandSetup-SettingUpYourStorageConfiguration)
+
+In this chart, you set the type of storage you want with `artifactory.persistence.type` and pass the required configuration settings.
+The default storage in this chart is the `file-system` replication, where the data is replicated to all nodes.
+
+> **IMPORTANT:** All storage configurations (except NFS) come with a default `artifactory.persistence.redundancy` parameter.
+This is used to set how many replicas of a binary should be stored in the cluster's nodes.
+Once this value is set on initial deployment, you can not update it using helm.
+It is recommended to set this to a number greater than half of your cluster's size, and never scale your cluster down to a size smaller than this number.
+
+#### NFS
+To use an NFS server as your cluster's storage, you need to
+- Setup an NFS server. Get its IP as `NFS_IP`
+- Create a `data` and `backup` directories on the NFS exported directory with write permissions to all
+- Pass NFS parameters to `helm install` and `helm upgrade`
+```bash
+...
+--set artifactory.persistence.type=nfs \
+--set artifactory.persistence.nfs.ip=${NFS_IP} \
+...
+```
+
+#### Google Storage
+To use a Google Storage bucket as the cluster's filestore. See [Google Storage Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-GoogleStorageBinaryProvider)
+- Pass Google Storage parameters to `helm install` and `helm upgrade`
+```bash
+...
+--set artifactory.persistence.type=google-storage \
+--set artifactory.persistence.googleStorage.identity=${GCP_ID} \
+--set artifactory.persistence.googleStorage.credential=${GCP_KEY} \
+...
+```
+
+#### AWS S3
+To use an AWS S3 bucket as the cluster's filestore. See [S3 Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-S3BinaryProvider)
+- Pass AWS S3 parameters to `helm install` and `helm upgrade`
+```bash
+...
+# With explicit credentials:
+--set artifactory.persistence.type=aws-s3 \
+--set artifactory.persistence.awsS3.endpoint=${AWS_S3_ENDPOINT} \
+--set artifactory.persistence.awsS3.region=${AWS_REGION} \
+--set artifactory.persistence.awsS3.identity=${AWS_ACCESS_KEY_ID} \
+--set artifactory.persistence.awsS3.credential=${AWS_SECRET_ACCESS_KEY} \
+...
+
+...
+# With using existing IAM role
+--set artifactory.persistence.type=aws-s3 \
+--set artifactory.persistence.awsS3.endpoint=${AWS_S3_ENDPOINT} \
+--set artifactory.persistence.awsS3.region=${AWS_REGION} \
+--set artifactory.persistence.awsS3.roleName=${AWS_ROLE_NAME} \
+...
+```
+**NOTE:** Make sure S3 `endpoint` and `region` match. See [AWS documentation on endpoint](https://docs.aws.amazon.com/general/latest/gr/rande.html)
+
+#### Microsoft Azure Blob Storage
+To use Azure Blob Storage as the cluster's filestore. See [Azure Blob Storage Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-AzureBlobStorageClusterBinaryProvider)
+- Pass Azure Blob Storage parameters to `helm install` and `helm upgrade`
+```bash
+...
+--set artifactory.persistence.type=azure-blob \
+--set artifactory.persistence.azureBlob.accountName=${AZURE_ACCOUNT_NAME} \
+--set artifactory.persistence.azureBlob.accountKey=${AZURE_ACCOUNT_KEY} \
+--set artifactory.persistence.azureBlob.endpoint=${AZURE_ENDPOINT} \
+--set artifactory.persistence.azureBlob.containerName=${AZURE_CONTAINER_NAME} \
+...
+```
 
 ### Customizing Database password
 You can override the specified database password (set in [values.yaml](values.yaml)), by passing it as a parameter in the install command line
@@ -270,6 +339,34 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.existingClaim` | Artifactory persistence volume claim name |                                       |
 | `artifactory.persistence.accessMode` | Artifactory persistence volume access mode | `ReadWriteOnce`                      |
 | `artifactory.persistence.size` | Artifactory persistence or local volume size | `20Gi`                                   |
+| `artifactory.persistence.type`         | Artifactory HA storage type                         | `file-system`                   |
+| `artifactory.persistence.redundancy`   | Artifactory HA storage redundancy                   | `3`                             |
+| `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |
+| `artifactory.persistence.nfs.haDataMount`   | NFS data directory                   | `/data`                             |
+| `artifactory.persistence.nfs.haBackupMount` | NFS backup directory                 | `/backup`                           |
+| `artifactory.persistence.nfs.dataDir`       | HA data directory                    | `/var/opt/jfrog/artifactory-ha`     |
+| `artifactory.persistence.nfs.backupDir`     | HA backup directory                  | `/var/opt/jfrog/artifactory-backup` |
+| `artifactory.persistence.nfs.capacity`      | NFS PVC size                         | `200Gi`                             |
+| `artifactory.persistence.eventual.numberOfThreads`  | Eventual number of threads   | `10`                                |
+| `artifactory.persistence.googleStorage.bucketName`  | Google Storage bucket name          | `artifactory-ha`             |
+| `artifactory.persistence.googleStorage.identity`    | Google Storage service account id   |                              |
+| `artifactory.persistence.googleStorage.credential`  | Google Storage service account key  |                              |
+| `artifactory.persistence.googleStorage.path`        | Google Storage path in bucket       | `artifactory-ha/filestore`   |
+| `artifactory.persistence.awsS3.bucketName`          | AWS S3 bucket name                     | `artifactory-ha`             |
+| `artifactory.persistence.awsS3.endpoint`            | AWS S3 bucket endpoint                 | See https://docs.aws.amazon.com/general/latest/gr/rande.html |
+| `artifactory.persistence.awsS3.region`              | AWS S3 bucket region                   |                              |
+| `artifactory.persistence.awsS3.roleName`            | AWS S3 IAM role name                   |                             |
+| `artifactory.persistence.awsS3.identity`            | AWS S3 AWS_ACCESS_KEY_ID               |                              |
+| `artifactory.persistence.awsS3.credential`          | AWS S3 AWS_SECRET_ACCESS_KEY           |                              |
+| `artifactory.persistence.awsS3.properties`          | AWS S3 additional properties           |                              |
+| `artifactory.persistence.awsS3.path`                | AWS S3 path in bucket                  | `artifactory-ha/filestore`   |
+| `artifactory.persistence.awsS3.refreshCredentials`  | AWS S3 renew credentials on expiration | `true` (When roleName is used, this parameter will be set to true) |
+| `artifactory.persistence.awsS3.testConnection`      | AWS S3 test connection on start up     | `false`                      |
+| `artifactory.persistence.azureBlob.accountName`     | Azure Blob Storage account name        | ``                        |
+| `artifactory.persistence.azureBlob.accountKey`      | Azure Blob Storage account key         | ``                        |
+| `artifactory.persistence.azureBlob.endpoint`        | Azure Blob Storage endpoint            | ``                        |
+| `artifactory.persistence.azureBlob.containerName`   | Azure Blob Storage container name      | ``                        |
+| `artifactory.persistence.azureBlob.testConnection`  | Azure Blob Storage test connection     | `false`                   |
 | `artifactory.resources.requests.memory` | Artifactory initial memory request                  |                          |
 | `artifactory.resources.requests.cpu`    | Artifactory initial cpu request     |                                          |
 | `artifactory.resources.limits.memory`   | Artifactory memory limit            |                                          |

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -344,24 +344,25 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |
 | `artifactory.persistence.nfs.haDataMount`   | NFS data directory                   | `/data`                             |
 | `artifactory.persistence.nfs.haBackupMount` | NFS backup directory                 | `/backup`                           |
-| `artifactory.persistence.nfs.dataDir`       | HA data directory                    | `/var/opt/jfrog/artifactory-ha`     |
+| `artifactory.persistence.nfs.dataDir`       | HA data directory                    | `/var/opt/jfrog/artifactory`     |
 | `artifactory.persistence.nfs.backupDir`     | HA backup directory                  | `/var/opt/jfrog/artifactory-backup` |
 | `artifactory.persistence.nfs.capacity`      | NFS PVC size                         | `200Gi`                             |
 | `artifactory.persistence.eventual.numberOfThreads`  | Eventual number of threads   | `10`                                |
-| `artifactory.persistence.googleStorage.bucketName`  | Google Storage bucket name          | `artifactory-ha`             |
+| `artifactory.persistence.googleStorage.bucketName`  | Google Storage bucket name          | `artifactory`             |
 | `artifactory.persistence.googleStorage.identity`    | Google Storage service account id   |                              |
 | `artifactory.persistence.googleStorage.credential`  | Google Storage service account key  |                              |
-| `artifactory.persistence.googleStorage.path`        | Google Storage path in bucket       | `artifactory-ha/filestore`   |
-| `artifactory.persistence.awsS3.bucketName`          | AWS S3 bucket name                     | `artifactory-ha`             |
+| `artifactory.persistence.googleStorage.path`        | Google Storage path in bucket       | `artifactory/filestore`   |
+| `artifactory.persistence.awsS3.bucketName`          | AWS S3 bucket name                     | `artifactory`             |
 | `artifactory.persistence.awsS3.endpoint`            | AWS S3 bucket endpoint                 | See https://docs.aws.amazon.com/general/latest/gr/rande.html |
 | `artifactory.persistence.awsS3.region`              | AWS S3 bucket region                   |                              |
 | `artifactory.persistence.awsS3.roleName`            | AWS S3 IAM role name                   |                             |
 | `artifactory.persistence.awsS3.identity`            | AWS S3 AWS_ACCESS_KEY_ID               |                              |
 | `artifactory.persistence.awsS3.credential`          | AWS S3 AWS_SECRET_ACCESS_KEY           |                              |
 | `artifactory.persistence.awsS3.properties`          | AWS S3 additional properties           |                              |
-| `artifactory.persistence.awsS3.path`                | AWS S3 path in bucket                  | `artifactory-ha/filestore`   |
+| `artifactory.persistence.awsS3.path`                | AWS S3 path in bucket                  | `artifactory/filestore`   |
 | `artifactory.persistence.awsS3.refreshCredentials`  | AWS S3 renew credentials on expiration | `true` (When roleName is used, this parameter will be set to true) |
 | `artifactory.persistence.awsS3.testConnection`      | AWS S3 test connection on start up     | `false`                      |
+| `artifactory.persistence.awsS3.s3AwsVersion`        | AWS S3 signature version               | `AWS4-HMAC-SHA256`                      |
 | `artifactory.persistence.azureBlob.accountName`     | Azure Blob Storage account name        | ``                        |
 | `artifactory.persistence.azureBlob.accountKey`      | Azure Blob Storage account key         | ``                        |
 | `artifactory.persistence.azureBlob.endpoint`        | Azure Blob Storage endpoint            | ``                        |

--- a/stable/artifactory/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory/templates/artifactory-binarystore.yaml
@@ -1,0 +1,175 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "artifactory.fullname" . }}-bs
+  labels:
+    app: {{ template "artifactory.name" . }}
+    chart: {{ template "artifactory.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  binarystore.xml: |-
+{{- if eq .Values.artifactory.persistence.type "file-system" }}
+    <!-- File system replication -->
+    <config version="v1">
+        <chain template="file-system"/>
+    </config>
+{{- end }}
+{{- if eq .Values.artifactory.persistence.type "google-storage" }}
+    <!-- Google storage -->
+    <config version="2">
+        <chain>
+            <provider id="sharding-cluster" type="sharding-cluster">
+                <readBehavior>crossNetworkStrategy</readBehavior>
+                <writeBehavior>crossNetworkStrategy</writeBehavior>
+                <redundancy>{{ .Values.artifactory.persistence.redundancy }}</redundancy>
+                <minSpareUploaderExecutor>2</minSpareUploaderExecutor>
+                <sub-provider id="eventual-cluster" type="eventual-cluster">
+                    <provider id="retry" type="retry">
+                        <provider id="google-storage" type="google-storage"/>
+                    </provider>
+                </sub-provider>
+                <dynamic-provider id="remote" type="remote"/>
+                <property name="zones" value="local,remote"/>
+            </provider>
+        </chain>
+
+        <!-- Set max cache-fs size -->
+        <provider id="cache-fs" type="cache-fs">
+            <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+        </provider>
+
+        <provider id="eventual-cluster" type="eventual-cluster">
+            <zone>local</zone>
+        </provider>
+
+        <provider id="remote" type="remote">
+            <checkPeriod>30</checkPeriod>
+            <timeout>10000</timeout>
+            <zone>remote</zone>
+        </provider>
+
+        <provider id="file-system" type="file-system">
+            <fileStoreDir>{{ .Values.artifactory.persistence.mountPath }}/data/filestore</fileStoreDir>
+            <tempDir>/tmp</tempDir>
+        </provider>
+
+        <provider id="google-storage" type="google-storage">
+            <providerId>google-cloud-storage</providerId>
+            <endpoint>commondatastorage.googleapis.com</endpoint>
+            <httpsOnly>false</httpsOnly>
+            <bucketName>{{ .Values.artifactory.persistence.googleStorage.bucketName }}</bucketName>
+            <identity>{{ .Values.artifactory.persistence.googleStorage.identity }}</identity>
+            <credential>{{ .Values.artifactory.persistence.googleStorage.credential }}</credential>
+            <path>{{ .Values.artifactory.persistence.googleStorage.path }}</path>
+        </provider>
+    </config>
+{{- end }}
+
+{{- if eq .Values.artifactory.persistence.type "aws-s3" }}
+    <!-- AWS S3 -->
+    <config version="2">
+        <chain> <!--template="cluster-s3"-->
+            <provider id="cache-fs" type="cache-fs">
+                <provider id="sharding-cluster" type="sharding-cluster">
+                    <sub-provider id="eventual-cluster" type="eventual-cluster">
+                        <provider id="retry-s3" type="retry">
+                            <provider id="s3" type="s3"/>
+                        </provider>
+                    </sub-provider>
+                    <dynamic-provider id="remote" type="remote"/>
+                </provider>
+            </provider>
+        </chain>
+
+        <!-- Set max cache-fs size -->
+        <provider id="cache-fs" type="cache-fs">
+            <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+        </provider>
+
+        <provider id="eventual-cluster" type="eventual-cluster">
+            <zone>local</zone>
+        </provider>
+
+        <provider id="remote" type="remote">
+            <checkPeriod>30</checkPeriod>
+            <timeout>10000</timeout>
+            <zone>remote</zone>
+        </provider>
+
+        <provider id="sharding-cluster" type="sharding-cluster">
+            <readBehavior>crossNetworkStrategy</readBehavior>
+            <writeBehavior>crossNetworkStrategy</writeBehavior>
+            <redundancy>{{ .Values.artifactory.persistence.redundancy }}</redundancy>
+            <property name="zones" value="local,remote"/>
+        </provider>
+
+        <provider id="s3" type="s3">
+            <endpoint>{{ .Values.artifactory.persistence.awsS3.endpoint }}</endpoint>
+        {{- if .Values.artifactory.persistence.awsS3.roleName }}
+            <roleName>{{ .Values.artifactory.persistence.awsS3.roleName }}</roleName>
+            <refreshCredentials>true</refreshCredentials>
+        {{- else }}
+            <refreshCredentials>{{ .Values.artifactory.persistence.awsS3.refreshCredentials }}</refreshCredentials>
+        {{- end }}
+            <testConnection>{{ .Values.artifactory.persistence.awsS3.testConnection }}</testConnection>
+            <httpsOnly>true</httpsOnly>
+            <region>{{ .Values.artifactory.persistence.awsS3.region }}</region>
+            <bucketName>{{ .Values.artifactory.persistence.awsS3.bucketName }}</bucketName>
+        {{- if .Values.artifactory.persistence.awsS3.identity }}
+            <identity>{{ .Values.artifactory.persistence.awsS3.identity }}</identity>
+        {{- end }}
+        {{- if .Values.artifactory.persistence.awsS3.credential }}
+            <credential>{{ .Values.artifactory.persistence.awsS3.credential }}</credential>
+        {{- end }}
+            <path>{{ .Values.artifactory.persistence.awsS3.path }}</path>
+        {{- range $key, $value := .Values.artifactory.persistence.awsS3.properties }}
+            <property name="{{ $key }}" value="{{ $value }}"/>
+        {{- end }}
+        </provider>
+    </config>
+{{- end }}
+
+{{- if eq .Values.artifactory.persistence.type "azure-blob" }}
+    <!-- Azure Blob Storage -->
+    <config version="2">
+        <chain> <!--template="cluster-azure-blob-storage"-->
+            <provider id="cache-fs" type="cache-fs">
+                <provider id="sharding-cluster" type="sharding-cluster">
+                    <sub-provider id="eventual-cluster" type="eventual-cluster">
+                        <provider id="retry-azure-blob-storage" type="retry">
+                            <provider id="azure-blob-storage" type="azure-blob-storage"/>
+                        </provider>
+                    </sub-provider>
+                    <dynamic-provider id="remote" type="remote"/>
+                </provider>
+            </provider>
+        </chain>
+    
+        <!-- cluster eventual Azure Blob Storage Service default chain -->
+        <provider id="sharding-cluster" type="sharding-cluster">
+            <readBehavior>crossNetworkStrategy</readBehavior>
+            <writeBehavior>crossNetworkStrategy</writeBehavior>
+            <redundancy>2</redundancy>
+            <lenientLimit>1</lenientLimit>
+            <property name="zones" value="local,remote"/>
+        </provider>
+    
+        <provider id="remote" type="remote">
+            <zone>remote</zone>
+        </provider>
+    
+        <provider id="eventual-cluster" type="eventual-cluster">
+            <zone>local</zone>
+        </provider>
+    
+        <!--cluster eventual template-->
+        <provider id="azure-blob-storage" type="azure-blob-storage">
+            <accountName>{{ .Values.artifactory.persistence.azureBlob.accountName }}</accountName>
+            <accountKey>{{ .Values.artifactory.persistence.azureBlob.accountKey }}</accountKey>
+            <endpoint>{{ .Values.artifactory.persistence.azureBlob.endpoint }}</endpoint>
+            <containerName>{{ .Values.artifactory.persistence.azureBlob.containerName }}</containerName>
+            <testConnection>{{ .Values.artifactory.persistence.azureBlob.testConnection }}</testConnection>
+        </provider>
+    </config>
+{{- end }}

--- a/stable/artifactory/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory/templates/artifactory-binarystore.yaml
@@ -19,8 +19,12 @@ data:
     <!-- Google storage -->
     <config version="2">
         <chain>
-            <provider id="retry" type="retry">
-                <provider id="google-storage" type="google-storage"/>
+            <provider id="cache-fs" type="cache-fs">
+                <provider id="eventual" type="eventual">
+                    <provider id="retry" type="retry">
+                        <provider id="google-storage" type="google-storage"/>
+                    </provider>
+                </provider>
             </provider>
         </chain>
 
@@ -51,8 +55,10 @@ data:
     <config version="2">
         <chain> <!--template="s3"-->
             <provider id="cache-fs" type="cache-fs">
-                <provider id="retry-s3" type="retry">
-                    <provider id="s3" type="s3"/>
+                <provider id="eventual" type="eventual">
+                    <provider id="retry-s3" type="retry">
+                        <provider id="s3" type="s3"/>
+                    </provider>
                 </provider>
             </provider>
         </chain>
@@ -94,11 +100,18 @@ data:
     <config version="2">
         <chain> <!--template="azure-blob-storage"-->
             <provider id="cache-fs" type="cache-fs">
-                <provider id="retry-azure-blob-storage" type="retry">
-                    <provider id="azure-blob-storage" type="azure-blob-storage"/>
+                <provider id="eventual" type="eventual">
+                    <provider id="retry-azure-blob-storage" type="retry">
+                        <provider id="azure-blob-storage" type="azure-blob-storage"/>
+                    </provider>
                 </provider>
             </provider>
         </chain>
+
+        <!-- Set max cache-fs size -->
+        <provider id="cache-fs" type="cache-fs">
+            <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+        </provider>
     
         <provider id="azure-blob-storage" type="azure-blob-storage">
             <accountName>{{ .Values.artifactory.persistence.azureBlob.accountName }}</accountName>

--- a/stable/artifactory/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory/templates/artifactory-binarystore.yaml
@@ -18,7 +18,11 @@ data:
 {{- if eq .Values.artifactory.persistence.type "google-storage" }}
     <!-- Google storage -->
     <config version="2">
-        <chain template="google-storage"/>
+        <chain>
+            <provider id="retry" type="retry">
+                <provider id="google-storage" type="google-storage"/>
+            </provider>
+        </chain>
 
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
@@ -45,7 +49,13 @@ data:
 {{- if eq .Values.artifactory.persistence.type "aws-s3" }}
     <!-- AWS S3 -->
     <config version="2">
-        <chain template="s3"/>
+        <chain> <!--template="s3"-->
+            <provider id="cache-fs" type="cache-fs">
+                <provider id="retry-s3" type="retry">
+                    <provider id="s3" type="s3"/>
+                </provider>
+            </provider>
+        </chain>
 
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
@@ -82,7 +92,13 @@ data:
 {{- if eq .Values.artifactory.persistence.type "azure-blob" }}
     <!-- Azure Blob Storage -->
     <config version="2">
-        <chain template="azure-blob-storage"/>
+        <chain> <!--template="azure-blob-storage"-->
+            <provider id="cache-fs" type="cache-fs">
+                <provider id="retry-azure-blob-storage" type="retry">
+                    <provider id="azure-blob-storage" type="azure-blob-storage"/>
+                </provider>
+            </provider>
+        </chain>
     
         <provider id="azure-blob-storage" type="azure-blob-storage">
             <accountName>{{ .Values.artifactory.persistence.azureBlob.accountName }}</accountName>

--- a/stable/artifactory/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory/templates/artifactory-binarystore.yaml
@@ -60,6 +60,7 @@ data:
         {{- else }}
             <refreshCredentials>{{ .Values.artifactory.persistence.awsS3.refreshCredentials }}</refreshCredentials>
         {{- end }}
+            <s3AwsVersion>{{ .Values.artifactory.persistence.awsS3.s3AwsVersion }}</s3AwsVersion>
             <testConnection>{{ .Values.artifactory.persistence.awsS3.testConnection }}</testConnection>
             <httpsOnly>true</httpsOnly>
             <region>{{ .Values.artifactory.persistence.awsS3.region }}</region>

--- a/stable/artifactory/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory/templates/artifactory-binarystore.yaml
@@ -18,35 +18,11 @@ data:
 {{- if eq .Values.artifactory.persistence.type "google-storage" }}
     <!-- Google storage -->
     <config version="2">
-        <chain>
-            <provider id="sharding-cluster" type="sharding-cluster">
-                <readBehavior>crossNetworkStrategy</readBehavior>
-                <writeBehavior>crossNetworkStrategy</writeBehavior>
-                <redundancy>{{ .Values.artifactory.persistence.redundancy }}</redundancy>
-                <minSpareUploaderExecutor>2</minSpareUploaderExecutor>
-                <sub-provider id="eventual-cluster" type="eventual-cluster">
-                    <provider id="retry" type="retry">
-                        <provider id="google-storage" type="google-storage"/>
-                    </provider>
-                </sub-provider>
-                <dynamic-provider id="remote" type="remote"/>
-                <property name="zones" value="local,remote"/>
-            </provider>
-        </chain>
+        <chain template="google-storage"/>
 
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
             <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
-        </provider>
-
-        <provider id="eventual-cluster" type="eventual-cluster">
-            <zone>local</zone>
-        </provider>
-
-        <provider id="remote" type="remote">
-            <checkPeriod>30</checkPeriod>
-            <timeout>10000</timeout>
-            <zone>remote</zone>
         </provider>
 
         <provider id="file-system" type="file-system">
@@ -69,39 +45,11 @@ data:
 {{- if eq .Values.artifactory.persistence.type "aws-s3" }}
     <!-- AWS S3 -->
     <config version="2">
-        <chain> <!--template="cluster-s3"-->
-            <provider id="cache-fs" type="cache-fs">
-                <provider id="sharding-cluster" type="sharding-cluster">
-                    <sub-provider id="eventual-cluster" type="eventual-cluster">
-                        <provider id="retry-s3" type="retry">
-                            <provider id="s3" type="s3"/>
-                        </provider>
-                    </sub-provider>
-                    <dynamic-provider id="remote" type="remote"/>
-                </provider>
-            </provider>
-        </chain>
+        <chain template="s3"/>
 
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
             <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
-        </provider>
-
-        <provider id="eventual-cluster" type="eventual-cluster">
-            <zone>local</zone>
-        </provider>
-
-        <provider id="remote" type="remote">
-            <checkPeriod>30</checkPeriod>
-            <timeout>10000</timeout>
-            <zone>remote</zone>
-        </provider>
-
-        <provider id="sharding-cluster" type="sharding-cluster">
-            <readBehavior>crossNetworkStrategy</readBehavior>
-            <writeBehavior>crossNetworkStrategy</writeBehavior>
-            <redundancy>{{ .Values.artifactory.persistence.redundancy }}</redundancy>
-            <property name="zones" value="local,remote"/>
         </provider>
 
         <provider id="s3" type="s3">
@@ -133,37 +81,8 @@ data:
 {{- if eq .Values.artifactory.persistence.type "azure-blob" }}
     <!-- Azure Blob Storage -->
     <config version="2">
-        <chain> <!--template="cluster-azure-blob-storage"-->
-            <provider id="cache-fs" type="cache-fs">
-                <provider id="sharding-cluster" type="sharding-cluster">
-                    <sub-provider id="eventual-cluster" type="eventual-cluster">
-                        <provider id="retry-azure-blob-storage" type="retry">
-                            <provider id="azure-blob-storage" type="azure-blob-storage"/>
-                        </provider>
-                    </sub-provider>
-                    <dynamic-provider id="remote" type="remote"/>
-                </provider>
-            </provider>
-        </chain>
+        <chain template="azure-blob-storage"/>
     
-        <!-- cluster eventual Azure Blob Storage Service default chain -->
-        <provider id="sharding-cluster" type="sharding-cluster">
-            <readBehavior>crossNetworkStrategy</readBehavior>
-            <writeBehavior>crossNetworkStrategy</writeBehavior>
-            <redundancy>2</redundancy>
-            <lenientLimit>1</lenientLimit>
-            <property name="zones" value="local,remote"/>
-        </provider>
-    
-        <provider id="remote" type="remote">
-            <zone>remote</zone>
-        </provider>
-    
-        <provider id="eventual-cluster" type="eventual-cluster">
-            <zone>local</zone>
-        </provider>
-    
-        <!--cluster eventual template-->
         <provider id="azure-blob-storage" type="azure-blob-storage">
             <accountName>{{ .Values.artifactory.persistence.azureBlob.accountName }}</accountName>
             <accountKey>{{ .Values.artifactory.persistence.azureBlob.accountKey }}</accountKey>

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -57,10 +57,6 @@ spec:
           mountPath: "{{ .Values.artifactory.persistence.nfs.dataDir }}"
         - name: artifactory-backup
           mountPath: "{{ .Values.artifactory.persistence.nfs.backupDir }}"
-      {{- else }}
-        - name: binarystore-xml
-          mountPath: "/artifactory_extra_conf/binarystore.xml"
-          subPath: binarystore.xml
       {{- end }}
     {{- end }}
       - name: "wait-for-db"
@@ -209,6 +205,16 @@ spec:
       {{- if .Values.artifactory.configMapName }}
         - name: bootstrap-config
           mountPath: "/bootstrap/"
+      {{- end }}
+      {{- if eq .Values.artifactory.persistence.type "nfs" }}
+        - name: artifactory-data
+          mountPath: "{{ .Values.artifactory.persistence.nfs.dataDir }}"
+        - name: artifactory-backup
+          mountPath: "{{ .Values.artifactory.persistence.nfs.backupDir }}"
+      {{- else }}
+        - name: binarystore-xml
+          mountPath: "/artifactory_extra_conf/binarystore.xml"
+          subPath: binarystore.xml
       {{- end }}
       {{- if .Values.artifactory.license.secret }}
         - name: artifactory-license

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -258,7 +258,7 @@ spec:
         - "-F"
         - "{{ $mountPath }}/logs/{{ . }}.log"
         volumeMounts:
-        - name: volume
+        - name: artifactory-volume
           mountPath: {{ $mountPath }}
       {{- end }}
       {{- end }}

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -26,6 +26,7 @@ spec:
         component: {{ .Values.artifactory.name }}
         release: {{ .Release.Name }}
       annotations:
+        checksum/binarystore: {{ include (print $.Template.BasePath "/artifactory-binarystore.yaml") . | sha256sum }}
       {{- range $key, $value := .Values.artifactory.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
@@ -49,8 +50,18 @@ spec:
         - '-c'
         - 'rm -rfv {{ .Values.artifactory.persistence.mountPath }}/lost+found {{ .Values.artifactory.persistence.mountPath }}/data/.lock'
         volumeMounts:
-        - mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
-          name: artifactory-volume
+        - name: artifactory-volume
+          mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
+      {{- if eq .Values.artifactory.persistence.type "nfs" }}
+        - name: artifactory-data
+          mountPath: "{{ .Values.artifactory.persistence.nfs.dataDir }}"
+        - name: artifactory-backup
+          mountPath: "{{ .Values.artifactory.persistence.nfs.backupDir }}"
+      {{- else }}
+        - name: binarystore-xml
+          mountPath: "/artifactory_extra_conf/binarystore.xml"
+          subPath: binarystore.xml
+      {{- end }}
     {{- end }}
       - name: "wait-for-db"
         image: "{{ .Values.initContainerImage }}"
@@ -264,6 +275,9 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+      - name: binarystore-xml
+        configMap:
+          name: {{ template "artifactory.fullname" . }}-bs
       {{- if and .Values.artifactory.persistence.enabled .Values.artifactory.persistence.existingClaim }}
       - name: artifactory-volume
         persistentVolumeClaim:
@@ -284,11 +298,28 @@ spec:
         secret:
           secretName: {{ .Values.artifactory.license.secret }}
       {{- end }}
-      {{- if and .Values.artifactory.persistence.enabled (not .Values.artifactory.persistence.existingClaim) }}
+      {{- if eq .Values.artifactory.persistence.type "nfs" }}
+      - name: artifactory-data
+        persistentVolumeClaim:
+          claimName: {{ template "artifactory.fullname" . }}-data-pvc
+      - name: artifactory-backup
+        persistentVolumeClaim:
+          claimName: {{ template "artifactory.fullname" . }}-backup-pvc
+      {{- end }}
+      {{- if not .Values.artifactory.persistence.enabled }}
+      - name: artifactory-volume
+        emptyDir:
+          sizeLimit: {{ .Values.artifactory.persistence.size }}
+      {{- else }}
   volumeClaimTemplates:
   - metadata:
       name: artifactory-volume
     spec:
+      {{- if .Values.artifactory.persistence.existingClaim }}
+      selector:
+        matchLabels:
+          app: artifactory
+      {{- else }}
       {{- if .Values.artifactory.persistence.storageClass }}
       {{- if (eq "-" .Values.artifactory.persistence.storageClass) }}
       storageClassName: ""
@@ -301,8 +332,4 @@ spec:
         requests:
           storage: {{ .Values.artifactory.persistence.size }}
       {{- end }}
-      {{- if not .Values.artifactory.persistence.enabled }}
-      - name: artifactory-volume
-        emptyDir:
-          sizeLimit: {{ .Values.artifactory.persistence.size }}
       {{- end }}

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -249,7 +249,7 @@ spec:
       {{- $tag := .image.tag }}
       {{- $mountPath := $.Values.artifactory.persistence.mountPath }}
       {{- range .names }}
-      - name: {{ . | replace "_" "-" }}
+      - name: {{ . | replace "_" "-" }}-logger
         image: {{ $image }}
         tag: {{ $tag }}
         command:

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -255,7 +255,7 @@ spec:
       {{- $tag := .image.tag }}
       {{- $mountPath := $.Values.artifactory.persistence.mountPath }}
       {{- range .names }}
-      - name: {{ . | replace "_" "-" }}-logger
+      - name: {{ . | replace "_" "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
         command:
@@ -312,11 +312,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ template "artifactory.fullname" . }}-backup-pvc
       {{- end }}
-      {{- if not .Values.artifactory.persistence.enabled }}
-      - name: artifactory-volume
-        emptyDir:
-          sizeLimit: {{ .Values.artifactory.persistence.size }}
-      {{- else }}
+      {{- if .Values.artifactory.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: artifactory-volume
@@ -338,4 +334,8 @@ spec:
         requests:
           storage: {{ .Values.artifactory.persistence.size }}
       {{- end }}
+      {{- else }}
+      - name: artifactory-volume
+        emptyDir:
+          sizeLimit: {{ .Values.artifactory.persistence.size }}
       {{- end }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -167,6 +167,58 @@ artifactory:
 
     accessMode: ReadWriteOnce
     size: 20Gi
+
+    ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
+    ## Supported types are:
+    ## file-system (default)
+    ## nfs
+    ## google-storage
+    ## aws-s3
+    ## azure-blob
+    type: file-system
+
+    ## For artifactory.persistence.type nfs
+    ## If using NFS as the shared storage, you must have a running NFS server that is accessible by your Kubernetes
+    ## cluster nodes.
+    ## Need to have the following set
+    nfs:
+      # Must pass actual IP of NFS server with '--set For artifactory.persistence.nfs.ip=${NFS_IP}'
+      ip:
+      haDataMount: "/data"
+      haBackupMount: "/backup"
+      dataDir: "/var/opt/jfrog/artifactory-ha"
+      backupDir: "/var/opt/jfrog/artifactory-backup"
+      capacity: 200Gi
+    ## For artifactory.persistence.type google-storage
+    googleStorage:
+      # Set a unique bucket name
+      bucketName: "artifactory-ha-gcp"
+      identity:
+      credential:
+      path: "artifactory-ha/filestore"
+    ## For artifactory.persistence.type aws-s3
+    ## IMPORTANT: Make sure S3 `endpoint` and `region` match! See https://docs.aws.amazon.com/general/latest/gr/rande.html
+    awsS3:
+      # Set a unique bucket name
+      bucketName: "artifactory-ha-aws"
+      endpoint:
+      region:
+      roleName:
+      identity:
+      credential:
+      path: "artifactory-ha/filestore"
+      refreshCredentials: true
+      testConnection: false
+      ## Additional properties to set on the s3 provider
+      properties: {}
+      #  httpclient.max-connections: 100
+    ## For artifactory.persistence.type azure-blob
+    azureBlob:
+      accountName:
+      accountKey:
+      endpoint:
+      containerName:
+      testConnection: false
     ## artifactory data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -186,29 +186,30 @@ artifactory:
       ip:
       haDataMount: "/data"
       haBackupMount: "/backup"
-      dataDir: "/var/opt/jfrog/artifactory-ha"
+      dataDir: "/var/opt/jfrog/artifactory"
       backupDir: "/var/opt/jfrog/artifactory-backup"
       capacity: 200Gi
     ## For artifactory.persistence.type google-storage
     googleStorage:
       # Set a unique bucket name
-      bucketName: "artifactory-ha-gcp"
+      bucketName: "artifactory-gcp"
       identity:
       credential:
-      path: "artifactory-ha/filestore"
+      path: "artifactory/filestore"
     ## For artifactory.persistence.type aws-s3
     ## IMPORTANT: Make sure S3 `endpoint` and `region` match! See https://docs.aws.amazon.com/general/latest/gr/rande.html
     awsS3:
       # Set a unique bucket name
-      bucketName: "artifactory-ha-aws"
+      bucketName: "artifactory-aws"
       endpoint:
       region:
       roleName:
       identity:
       credential:
-      path: "artifactory-ha/filestore"
+      path: "artifactory/filestore"
       refreshCredentials: true
       testConnection: false
+      s3AwsVersion: AWS4-HMAC-SHA256
       ## Additional properties to set on the s3 provider
       properties: {}
       #  httpclient.max-connections: 100

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -167,6 +167,8 @@ artifactory:
 
     accessMode: ReadWriteOnce
     size: 20Gi
+    maxCacheSize: 50000000000
+
 
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This chart ports the binarystore feature from the artifactory-ha chart. The reason for doing this is that we have a use case where we have an enterprise license, but wish to deploy without the primary/node setup of the HA chart.

The default binarystore will still use the file-system configuration.

**Which issue this PR fixes**
- fixes #171 

**Special notes for your reviewer**:

I _believe_ I have made these changes in a backwards compatible way (hence the minor version bump), I'm happy to go to 8.0.0 if this is a large enough change to warrant it.

Also, when I ported the the binarystore config I left the cloudprovider config mostly intact as I wasn't sure what would need to be changed for most of them. Is there a significant difference in cluster/non-clustered config that would stop it from working in a non-ha artifactory setup?
