### PR TITLE
Add support for logger sidecar containers in Distribution

### DIFF
--- a/stable/distribution/CHANGELOG.md
+++ b/stable/distribution/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Distribution Chart Changelog
 All changes to this project chart be documented in this file.
 
+## [3.2.0] - Mar 1, 2019
+* Support loggers sidecars to tail a configured log
+
 ## [3.1.0] - Feb 18, 2019
 * Update Distribution version 1.6.0
 

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: distribution
 description: A Helm chart for JFrog Distribution
-version: 3.1.0
+version: 3.2.0
 appVersion: 1.6.0
 home: https://jfrog.com/platform/
 icon: https://raw.githubusercontent.com/jfrog/artifactory-dcos/master/images/jfrog_med.png

--- a/stable/distribution/README.md
+++ b/stable/distribution/README.md
@@ -124,6 +124,19 @@ In cases where a new version is not compatible with existing deployed version (l
 * Update DNS to point to new Distribution service
 * Remove old release
 
+## Logger sidecars
+This chart provides the option to add sidecars to tail various logs from Distribution containers. See the available values in `values.yaml`
+
+ Get list of containers in the pod
+```bash
+kubectl get pods -n <NAMESPACE> <POD_NAME> -o jsonpath='{.spec.containers[*].name}' | tr ' ' '\n'
+```
+
+ View specific log
+```bash
+kubectl logs -n <NAMESPACE> <POD_NAME> -c <LOG_CONTAINER_NAME>
+```
+
 ## Custom init containers
 There are cases where a special, unsupported init processes is needed like checking something on the file system or testing something before spinning up the main container.
 
@@ -177,6 +190,8 @@ The following table lists the configurable parameters of the distribution chart 
 | `redis.nodeSelector`                         | Redis node selector                        | `{}`                               |
 | `redis.affinity`                             | Redis node affinity                        | `{}`                               |
 | `redis.tolerations`                          | Redis node tolerations                     | `[]`                               |
+| `logger.image.repository`                    | Repository for logger image                | `busybox`                          |
+| `logger.image.tag`                           | Tag for logger image                       | `1.30`                             |
 | `common.uid`                                 | Distribution and Distributor process user ID               | `1020`             |
 | `common.gid`                                 | Distribution and Distributor process group ID              | `1020`             |
 | `distribution.name`                          | Distribution name                          | `distribution`                     |
@@ -200,6 +215,7 @@ The following table lists the configurable parameters of the distribution chart 
 | `distribution.nodeSelector`                  | Distribution node selector                 | `{}`                               |
 | `distribution.affinity`                      | Distribution node affinity                 | `{}`                               |
 | `distribution.tolerations`                   | Distribution node tolerations              | `[]`                               |
+| `distribution.loggers`                       | Distribution loggers (see values.yaml for possible values)     | ` `            |
 | `distributor.name`                           | Distribution name                          | `distribution`                     |
 | `distributor.image.pullPolicy`               | Container pull policy                      | `IfNotPresent`                     |
 | `distributor.image.repository`               | Container image                            | `docker.jfrog.io/jf-distribution`  |
@@ -213,6 +229,7 @@ The following table lists the configurable parameters of the distribution chart 
 | `distributor.nodeSelector`                   | Distributor node selector                  | `{}`                               |
 | `distributor.affinity`                       | Distributor node affinity                  | `{}`                               |
 | `distributor.tolerations`                    | Distributor node tolerations               | `[]`                               |
+| `distributor.loggers`                        | Distributor loggers (see values.yaml for possible values)      | ` `            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/distribution/ci/test-values.yaml
+++ b/stable/distribution/ci/test-values.yaml
@@ -1,11 +1,11 @@
 # CI values for Distribution
 
-#replicaCount: 2
-#rbac:
-#  create: false
+# replicaCount: 2
+# rbac:
+#   create: false
 #
-#serviceAccount:
-#  create: false
+# serviceAccount:
+#   create: false
 
 postgresql:
   postgresPassword: password

--- a/stable/distribution/templates/distribution-statefulset.yaml
+++ b/stable/distribution/templates/distribution-statefulset.yaml
@@ -237,6 +237,38 @@ spec:
         volumeMounts:
         - name: redis-data
           mountPath: {{ .Values.redis.persistence.path }}
+      {{- $image := .Values.logger.image.repository }}
+      {{- $tag := .Values.logger.image.tag }}
+      {{- $name := .Values.distribution.name }}
+      {{- $mountPath := .Values.distribution.persistence.mountPath }}
+      {{- range .Values.distribution.loggers }}
+      - name: {{ $name }}-{{ . | replace "_" "-" | replace "." "-" }}
+        image: {{ $image }}
+        tag: {{ $tag }}
+        command:
+          - tail
+        args:
+          - "-F"
+          - "{{ $mountPath }}/logs/{{ . }}"
+        volumeMounts:
+          - name: distribution-data
+            mountPath: {{ $mountPath }}
+      {{- end }}
+      {{- $name := .Values.distributor.name }}
+      {{- $mountPath := .Values.distributor.persistence.mountPath }}
+      {{- range .Values.distributor.loggers }}
+      - name: {{ $name }}-{{ . | replace "_" "-" | replace "." "-" }}
+        image: {{ $image }}
+        tag: {{ $tag }}
+        command:
+          - tail
+        args:
+          - "-F"
+          - "{{ $mountPath }}/logs/{{ . }}"
+        volumeMounts:
+          - name: distributor-data
+            mountPath: {{ $mountPath }}
+      {{- end }}
   {{- with .Values.distribution.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/distribution/values.yaml
+++ b/stable/distribution/values.yaml
@@ -220,7 +220,8 @@ distribution:
     ##
     # storageClass: "-"
 
-  loggers: [] # Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
+  # Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
+  loggers: []
   # - access.log
   # - distribution.log
   # - request.log
@@ -267,7 +268,8 @@ distributor:
     ##
     # storageClass: "-"
 
-  loggers: [] # Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
+  # Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
+  loggers: []
   # - distributor.log
   # - foreman.log
 

--- a/stable/distribution/values.yaml
+++ b/stable/distribution/values.yaml
@@ -142,6 +142,11 @@ common:
   uid: 1020
   gid: 1020
 
+logger:
+  image:
+    repository: busybox
+    tag: 1.30
+
 distribution:
   name: distribution
   image:
@@ -215,6 +220,11 @@ distribution:
     ##
     # storageClass: "-"
 
+  loggers: [] # Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
+  # - access.log
+  # - distribution.log
+  # - request.log
+
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -256,6 +266,10 @@ distributor:
     ##   GKE, AWS & OpenStack)
     ##
     # storageClass: "-"
+
+  loggers: [] # Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
+  # - distributor.log
+  # - foreman.log
 
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Add support for running logger sidecar containers to view non default Distribution logs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #224 


