### PR TITLE
Add support for logger sidecar containers to Artifactory's Tomcat logs

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.11.2] - Mar 4, 2019
+* Add support for catalina logs sidecars
+
 ## [0.11.1] - Feb 27, 2019
 * Updated Artifactory version to 6.8.3
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.11.1
+version: 0.11.2
 appVersion: 6.8.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -347,10 +347,17 @@ helm install --name artifactory-ha --set imagePullSecrets=regsecret jfrog/artifa
 ```
 
 ### Logger sidecars
+This chart provides the option to add sidecars to tail various logs from Artifactory. See the available values in [values.yaml](values.yaml)
 
-This chart provides the option to add sidecars to tail various types of logs from artifactory. To see the potential values check the `artifactory.loggers` and `nginx.loggers` values in `values.yaml`
+Get list of containers in the pod
+```bash
+kubectl get pods -n <NAMESPACE> <POD_NAME> -o jsonpath='{.spec.containers[*].name}' | tr ' ' '\n'
+```
 
-To access a specific log run `kubectl logs -n <ARTIFACTORY_NAMESPACE> <ARTIFACTORY_POD_NAME> -c <LOG_NAME>`.
+View specific log
+```bash
+kubectl logs -n <NAMESPACE> <POD_NAME> -c <LOG_CONTAINER_NAME>
+```
 
 
 ### Custom init containers
@@ -381,6 +388,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.image.repository`       | Container image                      | `docker.bintray.io/jfrog/artifactory-pro`  |
 | `artifactory.image.version`          | Container image tag                  | `.Chart.AppVersion`                        |
 | `artifactory.loggers`             | Artifactory loggers (see values.yaml for possible values) | `[]`                     |
+| `artifactory.catalinaLoggers`     | Artifactory Tomcat loggers (see values.yaml for possible values) | `[]`              |
 | `artifactory.customInitContainers`| Custom init containers                  |                                            |
 | `artifactory.masterKey`           | Artifactory Master Key. Can be generated with `openssl rand -hex 32` |`FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF`|
 | `artifactory.masterKeySecretName` | Artifactory Master Key secret name                                   |                                                                  |

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -254,17 +254,34 @@ spec:
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.artifactory.persistence.mountPath }}
       {{- range .Values.artifactory.loggers }}
-      - name: {{ . | replace "_" "-" }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
         command:
         - tail
         args:
         - "-F"
-        - "{{ $mountPath }}/logs/{{ . }}.log"
+        - "{{ $mountPath }}/logs/{{ . }}"
         volumeMounts:
         - name: volume
           mountPath: {{ $mountPath }}
+      {{- end }}
+      {{ if .Values.artifactory.catalinaLoggers }}
+      {{- range .Values.artifactory.catalinaLoggers }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
+        image: {{ $image }}
+        tag: {{ $tag }}
+        command:
+        - 'sh'
+        - '-c'
+        - 'sh /scripts/tail-log.sh {{ $mountPath }}/logs/catalina {{ . }}'
+        volumeMounts:
+        - name: volume
+          mountPath: {{ $mountPath }}
+        - name: catalina-logger
+          mountPath: /scripts/tail-log.sh
+          subPath: tail-log.sh
+      {{- end }}
       {{- end }}
     {{- with .Values.artifactory.node.nodeSelector }}
       nodeSelector:
@@ -314,6 +331,11 @@ spec:
       - name: replicator-config
         configMap:
           name: {{ template "artifactory-ha.fullname" . }}-replicator-config
+      {{- end }}
+      {{- if .Values.artifactory.catalinaLoggers }}
+      - name: catalina-logger
+        configMap:
+          name: {{ template "artifactory-ha.fullname" . }}-catalina-logger
       {{- end }}
       {{- if eq .Values.artifactory.persistence.type "nfs" }}
       - name: artifactory-ha-data

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -266,17 +266,34 @@ spec:
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.artifactory.persistence.mountPath }}
       {{- range .Values.artifactory.loggers }}
-      - name: {{ . | replace "_" "-" }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
         command:
         - tail
         args:
         - "-F"
-        - "{{ $mountPath }}/logs/{{ . }}.log"
+        - "{{ $mountPath }}/logs/{{ . }}"
         volumeMounts:
         - name: volume
           mountPath: {{ $mountPath }}
+      {{- end }}
+      {{ if .Values.artifactory.catalinaLoggers }}
+      {{- range .Values.artifactory.catalinaLoggers }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
+        image: {{ $image }}
+        tag: {{ $tag }}
+        command:
+        - 'sh'
+        - '-c'
+        - 'sh /scripts/tail-log.sh {{ $mountPath }}/logs/catalina {{ . }}'
+        volumeMounts:
+        - name: volume
+          mountPath: {{ $mountPath }}
+        - name: catalina-logger
+          mountPath: /scripts/tail-log.sh
+          subPath: tail-log.sh
+      {{- end }}
       {{- end }}
     {{- with .Values.artifactory.primary.nodeSelector }}
       nodeSelector:
@@ -326,6 +343,11 @@ spec:
         configMap:
           name: {{ .Values.artifactory.configMapName }}
       {{- end}}
+      {{- if .Values.artifactory.catalinaLoggers }}
+      - name: catalina-logger
+        configMap:
+          name: {{ template "artifactory-ha.fullname" . }}-catalina-logger
+      {{- end }}
       {{- if .Values.artifactory.license.secret }}
       - name: artifactory-license
         secret:

--- a/stable/artifactory-ha/templates/catalina-logger-configmap.yaml
+++ b/stable/artifactory-ha/templates/catalina-logger-configmap.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.artifactory.catalinaLoggers }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "artifactory-ha.fullname" . }}-catalina-logger
+  labels:
+    app: {{ template "artifactory-ha.name" . }}
+    chart: {{ template "artifactory-ha.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  tail-log.sh: |
+    #!/bin/sh
+
+    LOG_DIR=$1
+    LOG_NAME=$2
+    PID=
+
+    # Wait for log dir to appear
+    while [ ! -d ${LOG_DIR} ]; do
+      sleep 1
+    done
+    sleep 5
+
+    cd ${LOG_DIR}
+
+    LOG_PREFIX=$(echo ${LOG_NAME} | awk -F\. '{print $1}')
+
+    # Find the log to tail
+    LOG_FILE=$(ls -1t ./${LOG_PREFIX}.*.log | head -1)
+
+    # echo "Tailing ${LOG_FILE}"
+    tail -F ${LOG_FILE} &
+    PID=$!
+
+    # Loop forever to see if a new log was created
+    while true; do
+        # Find the latest log
+        NEW_LOG_FILE=$(ls -1t ./${LOG_PREFIX}.*.log | head -1)
+
+        # If a new log file is found, kill old tail and switch to tailing it
+        if [ "${LOG_FILE}" != "${NEW_LOG_FILE}" ]; then
+            kill -9 ${PID}
+            wait $! 2>/dev/null
+            LOG_FILE=${NEW_LOG_FILE}
+
+            # echo "Tailing ${LOG_FILE}"
+            tail -F ${LOG_FILE} &
+            PID=$!
+        fi
+        sleep 2
+    done
+{{- end }}

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -157,16 +157,16 @@ spec:
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.nginx.persistence.mountPath }}
       {{- range .Values.nginx.loggers }}
-      - name: {{ . | replace "_" "-" }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
         command:
         - tail
         args:
         - "-F"
-        - "{{ $mountPath }}/logs/{{ . }}.log"
+        - "{{ $mountPath }}/logs/{{ . }}"
         volumeMounts:
-        - name: volume
+        - name: nginx-volume
           mountPath: {{ $mountPath }}
       {{- end }}
     {{- with .Values.nginx.nodeSelector }}

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -73,7 +73,7 @@ spec:
                 cp -Lrf /tmp/conf.d/artifactory*.conf /etc/nginx/conf.d/artifactory.conf;
                 {{- else }}
                 if ! grep -q 'upstream' /etc/nginx/conf.d/artifactory.conf; then
-                sed -i -e 's,proxy_pass .*,proxy_pass     http://{{ $serviceName }}:{{ $servicePort }}/artifactory/;,g' \
+                sed -i -e 's,proxy_pass.*http://artifactory.*/artifactory/\(.*\);,proxy_pass       http://{{ $serviceName }}:{{ $servicePort }}/artifactory/\1;,g' \
                     -e 's,server_name .*,server_name ~(?<repo>.+)\\.{{ $serviceName }} {{ $serviceName }};,g' \
                     /etc/nginx/conf.d/artifactory.conf;
                 fi;

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -119,14 +119,22 @@ artifactory:
     # version:
     pullPolicy: IfNotPresent
 
-  loggers: []  # add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
-  # - request
-  # - event
-  # - binarystore
-  # - request_trace
-  # - access
-  # - artifactory
-  # - build_info_migration
+  # Sidecar containers for tailing Artifactory logs
+  loggers: []
+  # - request.log
+  # - event.log
+  # - binarystore.log
+  # - request_trace.log
+  # - access.log
+  # - artifactory.log
+  # - build_info_migration.log
+
+  # Sidecar containers for tailing Tomcat (catalina) logs
+  catalinaLoggers: []
+  # - catalina.log
+  # - host-manager.log
+  # - localhost.log
+  # - manager.log
 
   ## Add custom init containers
   customInitContainers: |
@@ -383,9 +391,10 @@ nginx:
     # version:
     pullPolicy: IfNotPresent
 
-  loggers: []  # add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
-  # - access
-  # - error
+  # Sidecar containers for tailing Nginx logs
+  loggers: []
+  # - access.log
+  # - error.log
 
   service:
     ## For minikube, set this to NodePort, elsewhere use LoadBalancer

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.12.2] - Mar 4, 2019
+* Add support for catalina logs sidecars
+
 ## [7.12.1] - Feb 27, 2019
 * Updated Artifactory version to 6.8.3
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.12.1
+version: 7.12.2
 appVersion: 6.8.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -276,10 +276,17 @@ helm install --name artifactory --set imagePullSecrets=regsecret jfrog/artifacto
 ```
 
 ### Logger sidecars
+This chart provides the option to add sidecars to tail various logs from Artifactory. See the available values in [values.yaml](values.yaml)
 
-This chart provides the option to add sidecars to tail various types of logs from artifactory. To see the potential values check the `artifactory.loggers` and `nginx.loggers` values in `values.yaml`
+Get list of containers in the pod
+```bash
+kubectl get pods -n <NAMESPACE> <POD_NAME> -o jsonpath='{.spec.containers[*].name}' | tr ' ' '\n'
+```
 
-To access a specific log run `kubectl logs -n <ARTIFACTORY_NAMESPACE> <ARTIFACTORY_POD_NAME> -c <LOG_NAME>`.
+View specific log
+```bash
+kubectl logs -n <NAMESPACE> <POD_NAME> -c <LOG_CONTAINER_NAME>
+```
 
 ### Custom init containers
 There are cases where a special, unsupported init processes is needed like checking something on the file system or testing something before spinning up the main container.
@@ -310,6 +317,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.image.repository`    | Container image                   | `docker.bintray.io/jfrog/artifactory-pro`        |
 | `artifactory.image.version`       | Container tag                     |  `.Chart.AppVersion`                             |
 | `artifactory.loggers`             | Artifactory loggers (see values.yaml for possible values) | `[]`                     |
+| `artifactory.catalinaLoggers`     | Artifactory Tomcat loggers (see values.yaml for possible values) | `[]`              |
 | `artifactory.customInitContainers`| Custom init containers            |                                                  |
 | `artifactory.service.name`| Artifactory service name to be set in Nginx configuration | `artifactory`                    |
 | `artifactory.service.type`| Artifactory service type | `ClusterIP`                                                       |

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -254,17 +254,34 @@ spec:
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.artifactory.persistence.mountPath }}
       {{- range .Values.artifactory.loggers }}
-      - name: {{ . | replace "_" "-" }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
         command:
         - tail
         args:
         - "-F"
-        - "{{ $mountPath }}/logs/{{ . }}.log"
+        - "{{ $mountPath }}/logs/{{ . }}"
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ $mountPath }}
+      {{- end }}
+      {{ if .Values.artifactory.catalinaLoggers }}
+      {{- range .Values.artifactory.catalinaLoggers }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
+        image: {{ $image }}
+        tag: {{ $tag }}
+        command:
+        - 'sh'
+        - '-c'
+        - 'sh /scripts/tail-log.sh {{ $mountPath }}/logs/catalina {{ . }}'
+        volumeMounts:
+        - name: artifactory-volume
+          mountPath: {{ $mountPath }}
+        - name: catalina-logger
+          mountPath: /scripts/tail-log.sh
+          subPath: tail-log.sh
+      {{- end }}
       {{- end }}
     {{- with .Values.artifactory.nodeSelector }}
       nodeSelector:
@@ -297,6 +314,11 @@ spec:
         configMap:
           name: {{ .Values.artifactory.configMapName }}
       {{- end}}
+      {{- if .Values.artifactory.catalinaLoggers }}
+      - name: catalina-logger
+        configMap:
+          name: {{ template "artifactory.fullname" . }}-catalina-logger
+      {{- end }}
       {{- if .Values.artifactory.license.secret }}
       - name: artifactory-license
         secret:

--- a/stable/artifactory/templates/catalina-logger-configmap.yaml
+++ b/stable/artifactory/templates/catalina-logger-configmap.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.artifactory.catalinaLoggers }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "artifactory.fullname" . }}-catalina-logger
+  labels:
+    app: {{ template "artifactory.name" . }}
+    chart: {{ template "artifactory.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  tail-log.sh: |
+    #!/bin/sh
+
+    LOG_DIR=$1
+    LOG_NAME=$2
+    PID=
+
+    # Wait for log dir to appear
+    while [ ! -d ${LOG_DIR} ]; do
+      sleep 1
+    done
+    sleep 5
+
+    cd ${LOG_DIR}
+
+    LOG_PREFIX=$(echo ${LOG_NAME} | awk -F\. '{print $1}')
+
+    # Find the log to tail
+    LOG_FILE=$(ls -1t ./${LOG_PREFIX}.*.log | head -1)
+
+    # echo "Tailing ${LOG_FILE}"
+    tail -F ${LOG_FILE} &
+    PID=$!
+
+    # Loop forever to see if a new log was created
+    while true; do
+        # Find the latest log
+        NEW_LOG_FILE=$(ls -1t ./${LOG_PREFIX}.*.log | head -1)
+
+        # If a new log file is found, kill old tail and switch to tailing it
+        if [ "${LOG_FILE}" != "${NEW_LOG_FILE}" ]; then
+            kill -9 ${PID}
+            wait $! 2>/dev/null
+            LOG_FILE=${NEW_LOG_FILE}
+
+            # echo "Tailing ${LOG_FILE}"
+            tail -F ${LOG_FILE} &
+            PID=$!
+        fi
+        sleep 2
+    done
+{{- end }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -1,16 +1,23 @@
 {{- if .Values.nginx.enabled -}}
-apiVersion: extensions/v1beta1
+{{- $serviceName := include "artifactory.fullname" . -}}
+{{- $servicePort := .Values.artifactory.externalPort -}}
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "artifactory.nginx.fullname" . }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}
-    component: {{ .Values.nginx.name }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    component: {{ .Values.nginx.name }}
 spec:
   replicas: {{ .Values.nginx.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "artifactory.name" . }}
+      release: {{ .Release.Name }}
+      component: {{ .Values.nginx.name }}
   template:
     metadata:
       labels:
@@ -42,7 +49,7 @@ spec:
         - 'sh'
         - '-c'
         - >
-          until nc -z -w 2 {{ template "artifactory.fullname" . }} {{ .Values.artifactory.externalPort }} && echo artifactory ok; do
+          until nc -z -w 2 {{ $serviceName }} {{ $servicePort }} && echo artifactory ok; do
             sleep 2;
           done;
       securityContext:
@@ -50,7 +57,7 @@ spec:
         fsGroup: {{ .Values.nginx.gid }}
       containers:
       - name: {{ .Values.nginx.name }}
-        image: "{{ .Values.nginx.image.repository }}:{{ default .Chart.AppVersion .Values.nginx.image.version }}"
+        image: '{{ .Values.nginx.image.repository }}:{{ default .Chart.AppVersion .Values.nginx.image.version }}'
         imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
         lifecycle:
           postStart:
@@ -66,17 +73,17 @@ spec:
                 cp -Lrf /tmp/conf.d/artifactory*.conf /etc/nginx/conf.d/artifactory.conf;
                 {{- else }}
                 if ! grep -q 'upstream' /etc/nginx/conf.d/artifactory.conf; then
-                sed -i -e 's,proxy_pass .*,proxy_pass     http://{{ template "artifactory.fullname" . }}:{{ .Values.artifactory.externalPort }}/artifactory/;,g' \
-                    -e 's,server_name .*,server_name ~(?<repo>.+)\\.{{ template "artifactory.fullname" . }} {{ template "artifactory.fullname" . }};,g' \
+                sed -i -e 's,proxy_pass.*http://artifactory.*/artifactory/\(.*\);,proxy_pass       http://{{ $serviceName }}:{{ $servicePort }}/artifactory/\1;,g' \
+                    -e 's,server_name .*,server_name ~(?<repo>.+)\\.{{ $serviceName }} {{ $serviceName }};,g' \
                     /etc/nginx/conf.d/artifactory.conf;
                 fi;
                 {{- end }}
                 if [ -f /tmp/replicator-nginx.conf ]; then
-                cp -Lfv /tmp/replicator-nginx.conf /etc/nginx/conf.d/replicator-nginx.conf;
+                cp -fv /tmp/replicator-nginx.conf /etc/nginx/conf.d/replicator-nginx.conf;
                 fi;
                 if [ -f /tmp/ssl/*.crt ]; then
                 rm -rf /var/opt/jfrog/nginx/ssl/example.*;
-                cp -Lfv /tmp/ssl/* /var/opt/jfrog/nginx/ssl;
+                cp -fv /tmp/ssl/* /var/opt/jfrog/nginx/ssl;
                 fi;
                 until [ -f /etc/nginx/conf.d/artifactory.conf ]; do sleep 1; done;
                 sleep 5; nginx -s reload; touch /var/log/nginx/conf.done
@@ -85,7 +92,7 @@ spec:
           {{- if .Values.nginx.env.artUrl }}
           value: {{ .Values.nginx.env.artUrl }}
           {{- else }}
-          value: "http://{{ template "artifactory.fullname" . }}:{{ .Values.artifactory.externalPort }}/artifactory"
+          value: 'http://{{ $serviceName }}:{{ $servicePort }}/artifactory'
           {{- end }}
         - name: SSL
           value: "{{ .Values.nginx.env.ssl }}"
@@ -184,7 +191,7 @@ spec:
       - name: nginx-config
         configMap:
           name: {{ .Values.nginx.customConfigMap }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.nginx.customArtifactoryConfigMap }}
       - name: artifactory-nginx-config
         configMap:
@@ -201,5 +208,5 @@ spec:
       - name: ssl-secret-volume
         secret:
           secretName: {{ .Values.nginx.tlsSecretName }}
-      {{- end -}}
+      {{- end }}
 {{- end }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -150,16 +150,16 @@ spec:
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.nginx.persistence.mountPath }}
       {{- range .Values.nginx.loggers }}
-      - name: {{ . | replace "_" "-" }}
+      - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
         command:
         - tail
         args:
         - "-F"
-        - "{{ $mountPath }}/logs/{{ . }}.log"
+        - "{{ $mountPath }}/logs/{{ . }}"
         volumeMounts:
-        - name: volume
+        - name: nginx-volume
           mountPath: {{ $mountPath }}
       {{- end }}
     {{- with .Values.nginx.nodeSelector }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -71,14 +71,22 @@ artifactory:
     # version:
     pullPolicy: IfNotPresent
 
+  # Sidecar containers for tailing Artifactory logs
   loggers: []
-  # - request
-  # - event
-  # - binarystore
-  # - request_trace
-  # - access
-  # - artifactory
-  # - build_info_migration
+  # - request.log
+  # - event.log
+  # - binarystore.log
+  # - request_trace.log
+  # - access.log
+  # - artifactory.log
+  # - build_info_migration.log
+
+  # Sidecar containers for tailing Tomcat (catalina) logs
+  catalinaLoggers: []
+  # - catalina.log
+  # - host-manager.log
+  # - localhost.log
+  # - manager.log
 
   ## Add custom init containers
   customInitContainers: |
@@ -272,9 +280,10 @@ nginx:
     # version:
     pullPolicy: IfNotPresent
 
+  # Sidecar containers for tailing Nginx logs
   loggers: []
-  # - access
-  # - error
+  # - access.log
+  # - error.log
 
   service:
     ## For minikube, set this to NodePort, elsewhere use LoadBalancer


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
1. The Artifactory Tomcat logs (`logs/catalina/`) now have an option for sidecar loggers. See `artifactory.catalinaLoggers` in values.yaml.
2. Fix configuration errors in nginx volume name in the loggers
3. Align logger container naming with other charts

