### PR TITLE
copy bootstrap during preStart instead of postStart

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.11.11] - Mar 19, 2019
+* Move the copy of bootstrap config from postStart to preStart for Primary
+
 ## [0.11.11] - Mar 18, 2019
 * Disable the option to use nginx PVC with more than one replica
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.11.11
+version: 0.11.12
 appVersion: 6.8.7
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -80,15 +80,19 @@ spec:
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
-      {{- if .Values.artifactory.preStartCommand }}
         command:
         - '/bin/sh'
         - '-c'
         - >
+          {{- if .Values.artifactory.configMapName }}
+          echo "Copying bootstrap configs";
+          cp -Lrf /bootstrap/* /artifactory_extra_conf/;
+          {{- end }}
+          {{- if .Values.artifactory.preStartCommand }}
           echo "Running custom preStartCommand command";
           {{ .Values.artifactory.preStartCommand }};
+          {{- end }}
           /entrypoint-artifactory.sh
-      {{- end }}
         lifecycle:
           postStart:
             exec:
@@ -96,9 +100,6 @@ spec:
               - '/bin/sh'
               - '-c'
               - >
-                {{- if .Values.artifactory.configMapName }}
-                cp -Lrf /bootstrap/* /artifactory_extra_conf/;
-                {{- end }}
                 {{- if .Values.artifactory.postStartCommand }}
                 {{ .Values.artifactory.postStartCommand }}
                 {{- end }}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.12.12] - Mar 19, 2019
+* Move the copy of bootstrap config from postStart to preStart
+
 ## [7.12.11] - Mar 18, 2019
 * Add information about nginx persistence
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.12.11
+version: 7.12.12
 appVersion: 6.8.7
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -85,15 +85,19 @@ spec:
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
-      {{- if .Values.artifactory.preStartCommand }}
         command:
         - '/bin/sh'
         - '-c'
         - >
+          {{- if .Values.artifactory.configMapName }}
+          echo "Copying bootstrap configs";
+          cp -Lrf /bootstrap/* /artifactory_extra_conf/;
+          {{- end }}
+          {{- if .Values.artifactory.preStartCommand }}
           echo "Running custom preStartCommand command";
           {{ .Values.artifactory.preStartCommand }};
+          {{- end }}
           /entrypoint-artifactory.sh
-      {{- end }}
         lifecycle:
           postStart:
             exec:
@@ -101,9 +105,6 @@ spec:
               - '/bin/sh'
               - '-c'
               - >
-                {{- if .Values.artifactory.configMapName }}
-                cp -Lrf /bootstrap/* /artifactory_extra_conf/;
-                {{- end }}
                 {{- if .Values.artifactory.postStartCommand }}
                 {{ .Values.artifactory.postStartCommand }}
                 {{- end }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Copying the bootstrap configs are currently wired into the postStart. They need to be in the preStart so that they are on the filesystem before artifactory starts up.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
No github issue, but support.jfrog.com support ticket #: 100501

**Special notes for your reviewer**:
David Xu (JFrog) commented in the support ticket that this is indeed backwards behavior. 
