### PR TITLE
Custom healthcheck path for artifactory and artifactory-ha

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,10 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.11.16] - Mar 22, 2019
+* Added support for `<artifactory|nginx>.<readiness|liveness>Probe.path` to customise the paths used for health probes
+
+
 ## [0.11.15] - Mar 21, 2019
 * Added support for `artifactory.customSidecarContainers` to create custom sidecar containers
 * Added support for `artifactory.customVolumes` to create custom volumes

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.11.15
+version: 0.11.16
 appVersion: 6.8.7
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -458,12 +458,14 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.externalPortReplicator` | Replicator service external port | `6061`   |
 | `artifactory.extraEnvironmentVariables`          | Extra environment variables to pass to Artifactory. See [documentation](https://www.jfrog.com/confluence/display/RTF/Installing+with+Docker#InstallingwithDocker-SupportedEnvironmentVariables) |   |
 | `artifactory.livenessProbe.enabled`              | Enable liveness probe                     |  `true`                                               |
+| `artifactory.livenessProbe.path`                 | liveness probe HTTP Get path              |  `/artifactory/webapp/#/login`                        |
 | `artifactory.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated  | 180                                                   |
 | `artifactory.livenessProbe.periodSeconds`        | How often to perform the probe            | 10                                                    |
 | `artifactory.livenessProbe.timeoutSeconds`       | When the probe times out                  | 10                                                    |
 | `artifactory.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1  |
 | `artifactory.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 10 |
 | `artifactory.readinessProbe.enabled`              | would you like a readinessProbe to be enabled           |  `true`                                |
+| `artifactory.readinessProbe.path`                      | readiness probe HTTP Get path                           |  `/artifactory/webapp/#/login`           |
 | `artifactory.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 60                                                    |
 | `artifactory.readinessProbe.periodSeconds`       | How often to perform the probe            | 10                                                    |
 | `artifactory.readinessProbe.timeoutSeconds`      | When the probe times out                  | 10                                                    |
@@ -554,12 +556,14 @@ The following table lists the configurable parameters of the artifactory chart a
 | `nginx.internalPortReplicator` | Replicator service internal port | `6061`                          |
 | `nginx.externalPortReplicator` | Replicator service external port | `6061`                          |
 | `nginx.livenessProbe.enabled`              | would you like a liveness Probe to be enabled          |  `true`                                  |
+| `nginx.livenessProbe.path`                 | liveness probe HTTP Get path              |  `/artifactory/webapp/#/login`                    |
 | `nginx.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated  | 100                                                   |
 | `nginx.livenessProbe.periodSeconds`        | How often to perform the probe            | 10                                                    |
 | `nginx.livenessProbe.timeoutSeconds`       | When the probe times out                  | 10                                                    |
 | `nginx.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1  |
 | `nginx.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 10 |
 | `nginx.readinessProbe.enabled`             | would you like a readinessProbe to be enabled           |  `true`                                 |
+| `nginx.readinessProbe.path`                     | Readiness probe HTTP Get path                           |  `/artifactory/webapp/#/login` |
 | `nginx.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 60                                                    |
 | `nginx.readinessProbe.periodSeconds`       | How often to perform the probe            | 10                                                    |
 | `nginx.readinessProbe.timeoutSeconds`      | When the probe times out                  | 10                                                    |

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -231,7 +231,7 @@ spec:
         {{- if .Values.artifactory.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.artifactory.readinessProbe.path }}
             port: 8040
           initialDelaySeconds: {{ .Values.artifactory.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.artifactory.readinessProbe.periodSeconds }}
@@ -242,7 +242,7 @@ spec:
         {{- if .Values.artifactory.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.artifactory.livenessProbe.path }}
             port: 8040
           initialDelaySeconds: {{ .Values.artifactory.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.artifactory.livenessProbe.periodSeconds }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -244,7 +244,7 @@ spec:
         {{- if .Values.artifactory.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.artifactory.readinessProbe.path }}
             port: 8040
           initialDelaySeconds: {{ .Values.artifactory.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.artifactory.readinessProbe.periodSeconds }}
@@ -255,7 +255,7 @@ spec:
         {{- if .Values.artifactory.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.artifactory.livenessProbe.path }}
             port: 8040
           initialDelaySeconds: {{ .Values.artifactory.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.artifactory.livenessProbe.periodSeconds }}

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -134,7 +134,7 @@ spec:
         {{- if .Values.nginx.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.nginx.readinessProbe.path }}
             port: 80
           initialDelaySeconds: {{ .Values.nginx.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.nginx.readinessProbe.periodSeconds }}
@@ -145,7 +145,7 @@ spec:
         {{- if .Values.nginx.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.nginx.livenessProbe.path }}
             port: 80
           initialDelaySeconds: {{ .Values.nginx.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.nginx.livenessProbe.periodSeconds }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -238,6 +238,7 @@ artifactory:
   ## The following settings are to configure the frequency of the liveness and readiness probes
   livenessProbe:
     enabled: true
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 180
     failureThreshold: 10
     timeoutSeconds: 10
@@ -246,6 +247,7 @@ artifactory:
 
   readinessProbe:
     enabled: true
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 60
     failureThreshold: 10
     timeoutSeconds: 10
@@ -453,6 +455,7 @@ nginx:
   ## The following settings are to configure the frequency of the liveness and readiness probes
   livenessProbe:
     enabled: true
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 100
     failureThreshold: 10
     timeoutSeconds: 10
@@ -461,6 +464,7 @@ nginx:
 
   readinessProbe:
     enabled: true
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 60
     failureThreshold: 10
     timeoutSeconds: 10

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.12.16] - Mar 22, 2019
+* Added support for `<artifactory|nginx>.<readiness|liveness>Probe.path` to customise the paths used for health probes
+
 ## [7.12.15] - Mar 21, 2019
 * Added support for `artifactory.customSidecarContainers` to create custom sidecar containers
 * Added support for `artifactory.customVolumes` to create custom volumes

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.12.15
+version: 7.12.16
 appVersion: 6.8.7
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -364,6 +364,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.internalPortReplicator` | Replicator service internal port | `6061`                                         |
 | `artifactory.externalPortReplicator` | Replicator service external port | `6061`                                         |
 | `artifactory.livenessProbe.enabled`              | Enable liveness probe                     | `true`                    |
+| `artifactory.livenessProbe.path`                     | Liveness probe HTTP Get path                           |  `/artifactory/webapp/#/login` |
 | `artifactory.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated  | 180                       |
 | `artifactory.livenessProbe.periodSeconds`        | How often to perform the probe            | 10                        |
 | `artifactory.livenessProbe.timeoutSeconds`       | When the probe times out                  | 10                        |
@@ -375,6 +376,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.postStartCommand`                   | Command to run after container starts   |                             |
 | `artifactory.extraEnvironmentVariables`          | Extra environment variables to pass to Artifactory. See [documentation](https://www.jfrog.com/confluence/display/RTF/Installing+with+Docker#InstallingwithDocker-SupportedEnvironmentVariables) |   |
 | `artifactory.readinessProbe.enabled`             | would you like a readinessProbe to be enabled           |  `true`     |
+| `artifactory.readinessProbe.path`                     | Readiness probe HTTP Get path                           |  `/artifactory/webapp/#/login` |
 | `artifactory.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 60                        |
 | `artifactory.readinessProbe.periodSeconds`       | How often to perform the probe            | 10                        |
 | `artifactory.readinessProbe.timeoutSeconds`      | When the probe times out                  | 10                        |
@@ -452,12 +454,14 @@ The following table lists the configurable parameters of the artifactory chart a
 | `nginx.internalPortReplicator` | Replicator service internal port | `6061`                                               |
 | `nginx.externalPortReplicator` | Replicator service external port | `6061`                                               |
 | `nginx.livenessProbe.enabled`              | Enable liveness probe                     | `true`                          |
+| `nginx.livenessProbe.path`                     | Liveness probe HTTP Get path                           |  `/artifactory/webapp/#/login` |
 | `nginx.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated  | 60                              |
 | `nginx.livenessProbe.periodSeconds`        | How often to perform the probe            | 10                              |
 | `nginx.livenessProbe.timeoutSeconds`       | When the probe times out                  | 10                              |
 | `nginx.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 10 |
 | `nginx.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 1|
 | `nginx.readinessProbe.enabled`              | would you like a readinessProbe to be enabled           |  `true`          |
+| `nginx.readinessProbe.path`                     | Readiness probe HTTP Get path                           |  `/artifactory/webapp/#/login` |
 | `nginx.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 60                              |
 | `nginx.readinessProbe.periodSeconds`       | How often to perform the probe            | 10                              |
 | `nginx.readinessProbe.timeoutSeconds`      | When the probe times out                  | 10                              |

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -232,7 +232,7 @@ spec:
       {{- if .Values.artifactory.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.artifactory.readinessProbe.path }}
             port: 8040
           initialDelaySeconds: {{ .Values.artifactory.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.artifactory.readinessProbe.periodSeconds }}
@@ -243,7 +243,7 @@ spec:
       {{- if .Values.artifactory.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.artifactory.livenessProbe.path }}
             port: 8040
           initialDelaySeconds: {{ .Values.artifactory.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.artifactory.livenessProbe.periodSeconds }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -134,7 +134,7 @@ spec:
         {{- if .Values.nginx.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.nginx.readinessProbe.path }}
             port: 80
           initialDelaySeconds: {{ .Values.nginx.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.nginx.readinessProbe.periodSeconds }}
@@ -145,7 +145,7 @@ spec:
         {{- if .Values.nginx.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: '/artifactory/webapp/#/login'
+            path: {{ .Values.nginx.livenessProbe.path }}
             port: 80
           initialDelaySeconds: {{ .Values.nginx.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.nginx.livenessProbe.periodSeconds }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -190,6 +190,7 @@ artifactory:
   ## The following settings are to configure the frequency of the liveness and readiness probes
   livenessProbe:
     enabled: false
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 180
     failureThreshold: 10
     timeoutSeconds: 10
@@ -198,6 +199,7 @@ artifactory:
 
   readinessProbe:
     enabled: false
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 60
     failureThreshold: 10
     timeoutSeconds: 10
@@ -345,6 +347,7 @@ nginx:
   ## The following settings are to configure the frequency of the liveness and readiness probes
   livenessProbe:
     enabled: true
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 60
     failureThreshold: 10
     timeoutSeconds: 10
@@ -353,6 +356,7 @@ nginx:
 
   readinessProbe:
     enabled: true
+    path: '/artifactory/webapp/#/login'
     initialDelaySeconds: 60
     failureThreshold: 10
     timeoutSeconds: 10


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Allows users to customise the paths used for the various health probes. I'm adding this as I am attempting to make artifactory webapp run as the ROOT webapp in tomcat. I have everything working, but cannot enable the health probes as they refer to the `/artifactory` endpoint which no longer exists.

Another reason this is potentially useful is that it will allow customising the nginx probe so that if a user wants, they can create a custom healthcheck in the nginx configuration and use that for the readiness probe, while using the artifactory endpoint for liveness. This would allow nginx to go out of service rather than crashlooping when artifactory is unavailable.

**Special notes for your reviewer**:
At some point someone may want to make the nginx configuration mentioned above the default behaviour. Nginx shouldn't really crashloop by default when artifactory is unavailable.

