### PR TITLE
[stable/xray] Switch to StatefulSet for managing Xray components

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.11.0] - Mar 26, 2019
+* Switched to StatefulSets to preserve micro-service Ids
+
 ## [0.10.5] - Mar 18, 2019
 * Added label selector for Xray ingress
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.10.5
+version: 0.11.0
 appVersion: 2.7.3
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -240,6 +240,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `analysis.name`                                | Xray Analysis name                           | `xray-analysis`      |
 | `analysis.image`                               | Xray Analysis container image                | `docker.bintray.io/jfrog/xray-analysis` |
 | `analysis.replicaCount`                        | Xray Analysis replica count                  | `1`                  |
+| `analysis.updateStrategy`                      | Xray Analysis update strategy                | `RollingUpdate`      |
+| `analysis.podManagementPolicy`                 | Xray Analysis pod management policy          | `Parallel`           |
 | `analysis.internalPort`                        | Xray Analysis internal port                  | `7000`               |
 | `analysis.externalPort`                        | Xray Analysis external port                  | `7000`               |
 | `analysis.service.type`                        | Xray Analysis service type                   | `ClusterIP`          |
@@ -252,6 +254,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `indexer.name`                                 | Xray Indexer name                            | `xray-indexer`       |
 | `indexer.image`                                | Xray Indexer container image                 | `docker.bintray.io/jfrog/xray-indexer`  |
 | `indexer.replicaCount`                         | Xray Indexer replica count                   | `1`                  |
+| `indexer.updateStrategy`                       | Xray Indexer update strategy                 | `RollingUpdate`      |
+| `indexer.podManagementPolicy`                  | Xray Indexer pod management policy           | `Parallel`           |
 | `indexer.internalPort`                         | Xray Indexer internal port                   | `7002`               |
 | `indexer.externalPort`                         | Xray Indexer external port                   | `7002`               |
 | `indexer.service.type`                         | Xray Indexer service type                    | `ClusterIP`          |
@@ -264,6 +268,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `persist.name`                                 | Xray Persist name                            | `xray-persist`       |
 | `persist.image`                                | Xray Persist container image                 | `docker.bintray.io/jfrog/xray-persist`  |
 | `persist.replicaCount`                         | Xray Persist replica count                   | `1`                  |
+| `persist.updateStrategy`                       | Xray Persist update strategy                 | `RollingUpdate`      |
+| `persist.podManagementPolicy`                  | Xray Persist pod management policy           | `Parallel`           |
 | `persist.internalPort`                         | Xray Persist internal port                   | `7003`               |
 | `persist.externalPort`                         | Xray Persist external port                   | `7003`               |
 | `persist.service.type`                         | Xray Persist service type                    | `ClusterIP`          |
@@ -276,6 +282,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `server.name`                                  | Xray server name                             | `xray-server`        |
 | `server.image`                                 | Xray server container image                  | `docker.bintray.io/jfrog/xray-server`   |
 | `server.replicaCount`                          | Xray server replica count                    | `1`                  |
+| `server.updateStrategy`                        | Xray server update strategy                  | `RollingUpdate`      |
+| `server.podManagementPolicy`                   | Xray server pod management policy            | `Parallel`           |
 | `server.internalPort`                          | Xray server internal port                    | `8000`               |
 | `server.externalPort`                          | Xray server external port                    | `80`                 |
 | `server.service.name`                          | Xray server service name                     | `xray`               |

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -1,26 +1,29 @@
 apiVersion: apps/v1beta2
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: {{ template "xray-persist.fullname" . }}
+  name: {{ template "xray-analysis.fullname" . }}
   labels:
-    app: {{ template "xray.name" . }}
+    app: {{ template "xray-analysis.name" . }}
     chart: {{ template "xray.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: {{ .Values.persist.name }}
+    component: {{ .Values.analysis.name }}
 spec:
-  replicas: {{ .Values.persist.replicaCount }}
+  replicas: {{ .Values.analysis.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.analysis.updateStrategy }}
+  podManagementPolicy: {{ .Values.analysis.podManagementPolicy }}
   selector:
     matchLabels:
       app: {{ template "xray.name" . }}
       release: {{ .Release.Name }}
-      component: {{ .Values.persist.name }}
+      component: {{ .Values.analysis.name }}
   template:
     metadata:
       labels:
         app: {{ template "xray.name" . }}
         release: {{ .Release.Name }}
-        component: {{ .Values.persist.name }}
+        component: {{ .Values.analysis.name }}
     spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -112,8 +115,8 @@ spec:
 {{ tpl .Values.common.customInitContainers . | indent 6 }}
       {{- end }}
       containers:
-      - name: {{ .Values.persist.name }}
-        image: {{ .Values.persist.image }}:{{ default .Chart.AppVersion .Values.common.xrayVersion }}
+      - name: {{ .Values.analysis.name }}
+        image: {{ .Values.analysis.image }}:{{ default .Chart.AppVersion .Values.common.xrayVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
         - name: XRAYCONFIGPATH
@@ -128,31 +131,31 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         ports:
-        - containerPort: {{ .Values.persist.internalPort }}
+        - containerPort: {{ .Values.analysis.internalPort }}
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.common.xrayConfigPath }}"
         securityContext:
           allowPrivilegeEscalation: false
         resources:
-{{ toYaml .Values.persist.resources | indent 10 }}
+{{ toYaml .Values.analysis.resources | indent 10 }}
         readinessProbe:
           httpGet:
             path: /debug/pprof/
-            port: {{ .Values.persist.internalPort }}
+            port: {{ .Values.analysis.internalPort }}
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 10
         livenessProbe:
           httpGet:
             path: /debug/pprof/
-            port: {{ .Values.persist.internalPort }}
+            port: {{ .Values.analysis.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.common.xrayConfigPath }}
-      {{- range .Values.persist.loggers }}
+      {{- range .Values.analysis.loggers }}
       - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
@@ -180,7 +183,7 @@ spec:
       volumes:
       - name: data-volume
         emptyDir:
-          sizeLimit: {{ .Values.persist.storage.sizeLimit }}
+          sizeLimit: {{ .Values.analysis.storage.sizeLimit }}
       - name: config-volume
         emptyDir:
           sizeLimit: 1Gi

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1beta2
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "xray-indexer.fullname" . }}
   labels:
@@ -10,6 +10,9 @@ metadata:
     component: {{ .Values.indexer.name }}
 spec:
   replicas: {{ .Values.indexer.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.indexer.updateStrategy }}
+  podManagementPolicy: {{ .Values.indexer.podManagementPolicy }}
   selector:
     matchLabels:
       app: {{ template "xray.name" . }}

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -1,26 +1,29 @@
 apiVersion: apps/v1beta2
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: {{ template "xray-server.fullname" . }}
+  name: {{ template "xray-persist.fullname" . }}
   labels:
     app: {{ template "xray.name" . }}
     chart: {{ template "xray.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: {{ .Values.server.name }}
+    component: {{ .Values.persist.name }}
 spec:
-  replicas: {{ .Values.server.replicaCount }}
+  replicas: {{ .Values.persist.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.persist.updateStrategy }}
+  podManagementPolicy: {{ .Values.persist.podManagementPolicy }}
   selector:
     matchLabels:
       app: {{ template "xray.name" . }}
       release: {{ .Release.Name }}
-      component: {{ .Values.server.name }}
+      component: {{ .Values.persist.name }}
   template:
     metadata:
       labels:
         app: {{ template "xray.name" . }}
         release: {{ .Release.Name }}
-        component: {{ .Values.server.name }}
+        component: {{ .Values.persist.name }}
     spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -112,8 +115,8 @@ spec:
 {{ tpl .Values.common.customInitContainers . | indent 6 }}
       {{- end }}
       containers:
-      - name: {{ .Values.server.name }}
-        image: {{ .Values.server.image }}:{{ default .Chart.AppVersion .Values.common.xrayVersion }}
+      - name: {{ .Values.persist.name }}
+        image: {{ .Values.persist.image }}:{{ default .Chart.AppVersion .Values.common.xrayVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
         - name: XRAYCONFIGPATH
@@ -128,31 +131,31 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         ports:
-        - containerPort: {{ .Values.server.internalPort }}
+        - containerPort: {{ .Values.persist.internalPort }}
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.common.xrayConfigPath }}"
         securityContext:
           allowPrivilegeEscalation: false
         resources:
-{{ toYaml .Values.server.resources | indent 10 }}
+{{ toYaml .Values.persist.resources | indent 10 }}
         readinessProbe:
           httpGet:
-            path: /web/
-            port: {{ .Values.server.internalPort }}
+            path: /debug/pprof/
+            port: {{ .Values.persist.internalPort }}
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 10
         livenessProbe:
           httpGet:
-            path: /web/
-            port: {{ .Values.server.internalPort }}
+            path: /debug/pprof/
+            port: {{ .Values.persist.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.common.xrayConfigPath }}
-      {{- range .Values.server.loggers }}
+      {{- range .Values.persist.loggers }}
       - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
@@ -180,7 +183,7 @@ spec:
       volumes:
       - name: data-volume
         emptyDir:
-          sizeLimit: {{ .Values.server.storage.sizeLimit }}
+          sizeLimit: {{ .Values.persist.storage.sizeLimit }}
       - name: config-volume
         emptyDir:
           sizeLimit: 1Gi

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -1,26 +1,29 @@
 apiVersion: apps/v1beta2
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: {{ template "xray-analysis.fullname" . }}
+  name: {{ template "xray-server.fullname" . }}
   labels:
-    app: {{ template "xray-analysis.name" . }}
+    app: {{ template "xray.name" . }}
     chart: {{ template "xray.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: {{ .Values.analysis.name }}
+    component: {{ .Values.server.name }}
 spec:
-  replicas: {{ .Values.analysis.replicaCount }}
+  replicas: {{ .Values.server.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.server.updateStrategy }}
+  podManagementPolicy: {{ .Values.server.podManagementPolicy }}
   selector:
     matchLabels:
       app: {{ template "xray.name" . }}
       release: {{ .Release.Name }}
-      component: {{ .Values.analysis.name }}
+      component: {{ .Values.server.name }}
   template:
     metadata:
       labels:
         app: {{ template "xray.name" . }}
         release: {{ .Release.Name }}
-        component: {{ .Values.analysis.name }}
+        component: {{ .Values.server.name }}
     spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -112,8 +115,8 @@ spec:
 {{ tpl .Values.common.customInitContainers . | indent 6 }}
       {{- end }}
       containers:
-      - name: {{ .Values.analysis.name }}
-        image: {{ .Values.analysis.image }}:{{ default .Chart.AppVersion .Values.common.xrayVersion }}
+      - name: {{ .Values.server.name }}
+        image: {{ .Values.server.image }}:{{ default .Chart.AppVersion .Values.common.xrayVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
         - name: XRAYCONFIGPATH
@@ -128,31 +131,31 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         ports:
-        - containerPort: {{ .Values.analysis.internalPort }}
+        - containerPort: {{ .Values.server.internalPort }}
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.common.xrayConfigPath }}"
         securityContext:
           allowPrivilegeEscalation: false
         resources:
-{{ toYaml .Values.analysis.resources | indent 10 }}
+{{ toYaml .Values.server.resources | indent 10 }}
         readinessProbe:
           httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.analysis.internalPort }}
+            path: /web/
+            port: {{ .Values.server.internalPort }}
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 10
         livenessProbe:
           httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.analysis.internalPort }}
+            path: /web/
+            port: {{ .Values.server.internalPort }}
           initialDelaySeconds: 90
           periodSeconds: 10
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.common.xrayConfigPath }}
-      {{- range .Values.analysis.loggers }}
+      {{- range .Values.server.loggers }}
       - name: {{ . | replace "_" "-" | replace "." "-" }}
         image: {{ $image }}
         tag: {{ $tag }}
@@ -180,7 +183,7 @@ spec:
       volumes:
       - name: data-volume
         emptyDir:
-          sizeLimit: {{ .Values.analysis.storage.sizeLimit }}
+          sizeLimit: {{ .Values.server.storage.sizeLimit }}
       - name: config-volume
         emptyDir:
           sizeLimit: 1Gi

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -219,6 +219,8 @@ global:
 analysis:
   name: xray-analysis
   image: docker.bintray.io/jfrog/xray-analysis
+  updateStrategy: RollingUpdate
+  podManagementPolicy: Parallel
   replicaCount: 1
   internalPort: 7000
   externalPort: 7000
@@ -244,6 +246,8 @@ analysis:
 indexer:
   name: xray-indexer
   image: docker.bintray.io/jfrog/xray-indexer
+  updateStrategy: RollingUpdate
+  podManagementPolicy: Parallel
   replicaCount: 1
   internalPort: 7002
   externalPort: 7002
@@ -269,6 +273,8 @@ indexer:
 persist:
   name: xray-persist
   image: docker.bintray.io/jfrog/xray-persist
+  updateStrategy: RollingUpdate
+  podManagementPolicy: Parallel
   replicaCount: 1
   internalPort: 7003
   externalPort: 7003
@@ -294,6 +300,8 @@ persist:
 server:
   name: xray-server
   image: docker.bintray.io/jfrog/xray-server
+  updateStrategy: RollingUpdate
+  podManagementPolicy: Parallel
   replicaCount: 1
   internalPort: 8000
   externalPort: 80


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Switches the management of the Xray components from a `deployment` to a `statefulset`. My reason for wanting to do this is this:
* Currently every new microservice pod is given a unique Id
* microservice uses this unique Id as it's node Id
* microservice registers in Xray with node Id
* Pod eventually dies/gets moved/replaced etc.
* microservice is still registered in Xray, but marked as offline
* Wait a week and the High Availability page in Xray has pages and pages of offline microservices

While this isn't really a problem, I contacted JFrog about this and their recommendation was to set the node Id to something not unique. I figured the easiest way to achieve this was to use StatefulSets, as in theory what's actually being asked for is similar to a stable network Id.

**Special notes for your reviewer**:
I tagged this as WIP as I wanted to get opinions on it, but this is actually functional in it's current state.
If y'all are happy with this change I can remove that and we can merge it.
I've also tested the upgrade path from `0.10.5` to this version and it works as expected