### PR TITLE
Rolling update to kubexray when xray_config.yaml changes

### DIFF
--- a/stable/kubexray/CHANGELOG.md
+++ b/stable/kubexray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog KubeXray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.3.6]  - Apr 2, 2019
+* Rolling update to kubexray when xray_config.yaml changes
+
 ## [0.3.6]  - Mar 20, 2019
 * Updated Kubexray version to 0.1.2
 

--- a/stable/kubexray/Chart.yaml
+++ b/stable/kubexray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubexray
-version: 0.3.6
+version: 0.3.7
 appVersion: 0.1.2
 home: https://github.com/jfrog/kubexray
 description: KubeXray Helm chart

--- a/stable/kubexray/templates/deployment.yaml
+++ b/stable/kubexray/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-xray.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-xray.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "kubexray.fullname" . }}
       {{- if .Values.imagePullSecrets }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Prompt the kubexray deployment to roll the pod(s) when the xray_config.yaml changes.
I updated the slack webhook URL, and the pod hasn't reloaded the config. This change should fix that

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

