### PR TITLE
Allow secret names for user plugins to contain template language

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.12.5] - Aprl 03, 2019
+* Allow secret names for user plugins to contain template language
+
 ## [0.12.4] - Apr 02, 2019
 * Fix issue #253 (use existing PVC for data and backup storage)
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.12.4
+version: 0.12.5
 appVersion: 6.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -499,6 +499,14 @@ You can now pass the created `plugins.yaml` file to helm install command to depl
 helm install --name artifactory-ha -f plugins.yaml jfrog/artifactory-ha
 ```
 
+Alternatively, you may be in a situation in which you would like to create a secret in a Helm chart that depends on this chart. In this scenario, the name of the secret is likely dynamically generated via template functions, so passing a statically named secret isn't possible. In this case, the chart supports evaluating strings as templates via the [`tpl`](https://helm.sh/docs/charts_tips_and_tricks/#using-the-tpl-function) function - simply pass the raw string containing the templating language used to name your secret as a value instead by adding the following to your chart's `values.yaml` file:
+```yaml
+artifactory-ha: # Name of the artifactory-ha dependency
+  artifactory:
+    userPluginSecrets:
+      - '{{ template "my-chart.fullname" . }}'
+```
+
 ## Configuration
 The following table lists the configurable parameters of the artifactory chart and their default values.
 

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -216,8 +216,8 @@ spec:
         volumeMounts:
       {{- if .Values.artifactory.userPluginSecrets }}
       {{- range .Values.artifactory.userPluginSecrets }}
-        - name: {{ . }}
-          mountPath: "/tmp/plugin/{{ . }}"
+        - name: {{ tpl . $ }}
+          mountPath: "/tmp/plugin/{{ tpl . $ }}"
       {{- end }}
       {{- end }}
         - name: volume
@@ -343,9 +343,9 @@ spec:
           name: {{ template "artifactory-ha.fullname" . }}-bs
       {{- if .Values.artifactory.userPluginSecrets }}
       {{- range .Values.artifactory.userPluginSecrets }}
-      - name: {{ . }}
+      - name: {{ tpl . $ }}
         secret:
-          secretName: {{ . }}
+          secretName: {{ tpl . $ }}
       {{- end }}
       {{- end }}
       {{- if .Values.artifactory.replicator.enabled }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -249,8 +249,8 @@ spec:
         volumeMounts:
       {{- if .Values.artifactory.userPluginSecrets }}
       {{- range .Values.artifactory.userPluginSecrets }}
-        - name: {{ . }}
-          mountPath: "/tmp/plugin/{{ . }}"
+        - name: {{ tpl . $ }}
+          mountPath: "/tmp/plugin/{{ tpl . $ }}"
       {{- end }}
       {{- end }}
         - name: volume
@@ -396,9 +396,9 @@ spec:
           name: {{ template "artifactory-ha.fullname" . }}-bs
       {{- if .Values.artifactory.userPluginSecrets }}
       {{- range .Values.artifactory.userPluginSecrets }}
-      - name: {{ . }}
+      - name: {{ tpl . $ }}
         secret:
-          secretName: {{ . }}
+          secretName: {{ tpl . $ }}
       {{- end }}
       {{- end }}
       {{- if .Values.artifactory.replicator.enabled }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -242,6 +242,7 @@ artifactory:
   #  - archive-old-artifacts
   #  - build-cleanup
   #  - webhook
+  #  - '{{ template "my-chart.fullname" . }}'
 
   ## Extra pre-start command to install JDBC driver for MySql/MariaDb/Oracle
   # preStartCommand: "curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar"

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.13.4] - Aprl 03, 2019
+* Allow secret names for user plugins to contain template language
+
 ## [7.13.3] - Apr 02, 2019
 * Allow NetworkPolicy configurations (defaults to allow all)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.13.3
+version: 7.13.4
 appVersion: 6.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -392,6 +392,14 @@ You can now pass the created `plugins.yaml` file to helm install command to depl
 helm install --name artifactory -f plugins.yaml jfrog/artifactory
 ```
 
+Alternatively, you may be in a situation in which you would like to create a secret in a Helm chart that depends on this chart. In this scenario, the name of the secret is likely dynamically generated via template functions, so passing a statically named secret isn't possible. In this case, the chart supports evaluating strings as templates via the [`tpl`](https://helm.sh/docs/charts_tips_and_tricks/#using-the-tpl-function) function - simply pass the raw string containing the templating language used to name your secret as a value instead by adding the following to your chart's `values.yaml` file:
+```yaml
+artifactory: # Name of the artifactory dependency
+  artifactory:
+    userPluginSecrets:
+      - '{{ template "my-chart.fullname" . }}'
+```
+
 ## Configuration
 The following table lists the configurable parameters of the artifactory chart and their default values.
 

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -214,8 +214,8 @@ spec:
         volumeMounts:
       {{- if .Values.artifactory.userPluginSecrets }}
       {{- range .Values.artifactory.userPluginSecrets }}
-        - name: {{ . }}
-          mountPath: "/tmp/plugin/{{ . }}"
+        - name: {{ tpl . $ }}
+          mountPath: "/tmp/plugin/{{ tpl . $ }}"
       {{- end }}
       {{- end }}
         - name: artifactory-volume
@@ -329,9 +329,9 @@ spec:
           name: {{ template "artifactory.fullname" . }}-bs
       {{- if .Values.artifactory.userPluginSecrets }}
       {{- range .Values.artifactory.userPluginSecrets }}
-      - name: {{ . }}
+      - name: {{ tpl . $ }}
         secret:
-          secretName: {{ . }}
+          secretName: {{ tpl . $ }}
       {{- end }}
       {{- end }}
       {{- if and .Values.artifactory.persistence.enabled .Values.artifactory.persistence.existingClaim }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -182,6 +182,7 @@ artifactory:
   #  - archive-old-artifacts
   #  - build-cleanup
   #  - webhook
+  #  - '{{ template "my-chart.fullname" . }}'
 
   masterKey: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
   ## Alternatively, you can use a pre-existing secret with a key called master-key by specifying masterKeySecretName


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Our organization deploys a Helm chart that actually has a dependency on the `artifactory-ha` chart. Now that the Artifactory chart supports user plugins, we'll create the secrets containing the user plugins in our 'wrapper' chart. Since the names of the secrets are named according to the output of template functions, we don't have a hardcoded secret name that we can pass to Artifactory. This PR updates the Artifactory chart to allow the names of externally provided secrets to contain template language

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

FYI @jainishshah17 @eldada - This is the change I was suggesting in https://github.com/jfrog/charts/pull/278#discussion_r270626240