### PR TITLE
Added support for cacheProviderDir

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.12.19] - Apr 28, 2019
+* Added support for `cacheProviderDir`
+
 ## [0.12.18] - Apr 18, 2019
 * Changing API StatefulSet version to `v1` and permission fix for custom `artifactory.conf` for Nginx
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.12.18
+version: 0.12.19
 appVersion: 6.9.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -601,6 +601,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.accessMode`   | Artifactory persistence volume access mode          | `ReadWriteOnce`                 |
 | `artifactory.persistence.size`         | Artifactory persistence or local volume size        | `200Gi`                         |
 | `artifactory.persistence.maxCacheSize` | Artifactory cache-fs provider maxCacheSize in bytes | `50000000000`                   |
+| `artifactory.persistence.cacheProviderDir` | the root folder of binaries for the filestore cache. If the value specified starts with a forward slash ("/") it is considered the fully qualified path to the filestore folder. Otherwise, it is considered relative to the *baseDataDir*. | `cache`                   |
 | `artifactory.persistence.type`         | Artifactory HA storage type                         | `file-system`                   |
 | `artifactory.persistence.redundancy`   | Artifactory HA storage redundancy                   | `3`                             |
 | `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |

--- a/stable/artifactory-ha/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory-ha/templates/artifactory-binarystore.yaml
@@ -208,6 +208,12 @@ data:
             </provider>
         </chain>
     
+        <!-- Set max cache-fs size -->
+        <provider id="cache-fs" type="cache-fs">
+            <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+            <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
+        </provider>
+
         <!-- cluster eventual Azure Blob Storage Service default chain -->
         <provider id="sharding-cluster" type="sharding-cluster">
             <readBehavior>crossNetworkStrategy</readBehavior>

--- a/stable/artifactory-ha/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory-ha/templates/artifactory-binarystore.yaml
@@ -95,6 +95,7 @@ data:
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
             <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+            <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
         </provider>
 
         <provider id="eventual-cluster" type="eventual-cluster">
@@ -144,6 +145,7 @@ data:
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
             <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+            <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
         </provider>
 
         <provider id="eventual-cluster" type="eventual-cluster">

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -319,6 +319,7 @@ artifactory:
     accessMode: ReadWriteOnce
     size: 200Gi
     maxCacheSize: 50000000000
+    cacheProviderDir: cache
     eventual:
       numberOfThreads: 10
     ## artifactory data Persistent Volume Storage Class

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.13.17] - Apr 25, 2019
+* Added support for `cacheProviderDir`
+
 ## [7.13.16] - Apr 18, 2019
 * Changing API StatefulSet version to `v1` and permission fix for custom `artifactory.conf` for Nginx
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.13.16
+version: 7.13.17
 appVersion: 6.9.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -504,9 +504,9 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.existingClaim` | Artifactory persistence volume claim name |                                       |
 | `artifactory.persistence.accessMode` | Artifactory persistence volume access mode | `ReadWriteOnce`                      |
 | `artifactory.persistence.size` | Artifactory persistence or local volume size | `20Gi`                                   |
-| `artifactory.persistence.type`         | Artifactory HA storage type                         | `file-system`                   |
 | `artifactory.persistence.maxCacheSize` | The maximum storage allocated for the cache in bytes. | `50000000000`                   |
 | `artifactory.persistence.cacheProviderDir` | the root folder of binaries for the filestore cache. If the value specified starts with a forward slash ("/") it is considered the fully qualified path to the filestore folder. Otherwise, it is considered relative to the *baseDataDir*. | `cache`                   |
+| `artifactory.persistence.type`         | Artifactory HA storage type                         | `file-system`                   |
 | `artifactory.persistence.redundancy`   | Artifactory HA storage redundancy                   | `3`                             |
 | `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |
 | `artifactory.persistence.nfs.haDataMount`   | NFS data directory                   | `/data`                             |

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -168,6 +168,15 @@ To use Azure Blob Storage as the cluster's filestore. See [Azure Blob Storage Bi
 ...
 ```
 
+* To use a persistent volume claim as cache dir together with Azure Blob Storage, additionally pass the following parameters to `helm  install` and `helm upgrade` (make sure `mountPath` and `cacheProviderDir` point to the same location)
+```bash
+...
+--set artifactory.persistence.existingClaim=${YOUR_CLAIM} \
+--set artifactory.persistence.mountPath=/opt/cache-dir \
+--set artifactory.persistence.cacheProviderDir=/opt/cache-dir \
+...
+```
+
 ### Customizing Database password
 You can override the specified database password (set in [values.yaml](values.yaml)), by passing it as a parameter in the install command line
 ```bash
@@ -496,6 +505,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.accessMode` | Artifactory persistence volume access mode | `ReadWriteOnce`                      |
 | `artifactory.persistence.size` | Artifactory persistence or local volume size | `20Gi`                                   |
 | `artifactory.persistence.type`         | Artifactory HA storage type                         | `file-system`                   |
+| `artifactory.persistence.maxCacheSize` | The maximum storage allocated for the cache in bytes. | `50000000000`                   |
+| `artifactory.persistence.cacheProviderDir` | the root folder of binaries for the filestore cache. If the value specified starts with a forward slash ("/") it is considered the fully qualified path to the filestore folder. Otherwise, it is considered relative to the *baseDataDir*. | `cache`                   |
 | `artifactory.persistence.redundancy`   | Artifactory HA storage redundancy                   | `3`                             |
 | `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |
 | `artifactory.persistence.nfs.haDataMount`   | NFS data directory                   | `/data`                             |

--- a/stable/artifactory/templates/artifactory-binarystore.yaml
+++ b/stable/artifactory/templates/artifactory-binarystore.yaml
@@ -31,6 +31,7 @@ data:
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
             <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+            <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
         </provider>
 
         <provider id="file-system" type="file-system">
@@ -67,6 +68,7 @@ data:
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
             <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+            <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
         </provider>
 
         <provider id="s3" type="s3">
@@ -112,6 +114,7 @@ data:
         <!-- Set max cache-fs size -->
         <provider id="cache-fs" type="cache-fs">
             <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+            <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
         </provider>
     
         <provider id="azure-blob-storage" type="azure-blob-storage">

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -275,6 +275,7 @@ artifactory:
     accessMode: ReadWriteOnce
     size: 20Gi
     maxCacheSize: 50000000000
+    cacheProviderDir: cache
 
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR allows to set the `cacheProviderDir`. As a result, one can use persistent volume claims together with Azure BLOB Storage when settings `cacheProviderDir` and `mountPath` to the same directory.
