### PR TITLE
Add the option to set artifactory.async.corePoolSize in the artifacto…

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.12.23] - May 5, 2019
+* Add support for setting `artifactory.async.corePoolSize`
+
 ## [0.12.22] - May 2, 2019
 * Remove unused property `artifactory.releasebundle.feature.enabled`
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.12.22
+version: 0.12.23
 appVersion: 6.9.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -681,6 +681,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.primary.resources.limits.cpu`      | Artifactory primary node cpu limit               |                     |
 | `artifactory.primary.javaOpts.xms`              | Artifactory primary node java Xms size           |                     |
 | `artifactory.primary.javaOpts.xmx`              | Artifactory primary node java Xms size           |                     |
+| `artifactory.primary.javaOpts.corePoolSize` | The number of async processes that can run in parallel in the primary node - https://jfrog.com/knowledge-base/how-do-i-tune-artifactory-for-heavy-loads/  |   `16` |
 | `artifactory.primary.javaOpts.jmx.enabled`              | Enable JMX monitoring           |  `false`                                        |
 | `artifactory.primary.javaOpts.jmx.port`              | JMX Port number            |  `9010`                                        |
 | `artifactory.primary.javaOpts.jmx.host`              | JMX hostname (parsed as a helm template)   |  `{{ template "artifactory-ha.primary.name" $ }}` |
@@ -695,6 +696,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.node.resources.limits.cpu`         | Artifactory member node cpu limit                |                     |
 | `artifactory.node.javaOpts.xms`                 | Artifactory member node java Xms size            |                     |
 | `artifactory.node.javaOpts.xmx`                 | Artifactory member node java Xms size            |                     |
+| `artifactory.node.javaOpts.corePoolSize` | The number of async processes that can run in parallel in the member nodes - https://jfrog.com/knowledge-base/how-do-i-tune-artifactory-for-heavy-loads/  |   `16` |
 | `artifactory.node.javaOpts.jmx.enabled`              | Enable JMX monitoring           |  `false`                                        |
 | `artifactory.node.javaOpts.jmx.port`              | JMX Port number            |  `9010`                                        |
 | `artifactory.node.javaOpts.jmx.host`              | JMX hostname (parsed as a helm template)           |  `{{ template "artifactory-ha.fullname" $ }}` |

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -183,6 +183,7 @@ spec:
         - name: EXTRA_JAVA_OPTIONS
           value: >
         {{- with .Values.artifactory.node.javaOpts }}
+            -Dartifactory.async.corePoolSize={{ .corePoolSize }}
           {{- if .xms }}
             -Xms{{ .xms }}
           {{- end }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -192,6 +192,7 @@ spec:
         - name: EXTRA_JAVA_OPTIONS
           value: >
         {{- with .Values.artifactory.primary.javaOpts }}
+            -Dartifactory.async.corePoolSize={{ .corePoolSize }}
           {{- if .xms }}
             -Xms{{ .xms }}
           {{- end }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -450,6 +450,7 @@ artifactory:
     javaOpts:
       # xms: "1g"
       # xmx: "2g"
+      corePoolSize: 16
       jmx:
         enabled: false
         port: 9010
@@ -488,6 +489,7 @@ artifactory:
     javaOpts:
       # xms: "1g"
       # xmx: "2g"
+      corePoolSize: 16
       jmx:
         enabled: false
         port: 9010


### PR DESCRIPTION
…ry-ha chart

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds support for setting ```artifactory.async.corePoolSize``` in the artifactory-ha chart

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #318 
