### PR TITLE
Simplify adding connection strings to 'xray_config.yaml'

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,10 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.12.4] - Apr 15, 2019
+* Simplify handling connection strings setup in `xray_config.yaml` to better support ampersand in external connection strings
+* **IMPORTANT:** If using an external connection string for PostgreSQL or MongoDB, **do not escape** the ampersand with `\`
+
 ## [0.12.3] - Apr 15, 2019
 * Move `skipEntLicCheckForCloud: true` config to be part of default Xray config
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.12.3
+version: 0.12.4
 appVersion: 2.8.0
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -140,10 +140,10 @@ For this, pass the parameter: `mongodb.enabled=false` and `global.mongoUrl=${XRA
 # MongoDB user: xray
 # MongoDB password: password1_X
 
-export XRAY_MONGODB_CONN_URL='mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@custom-mongodb.local:27017/?authSource=${MONGODB_DATABASE}\&authMechanism=SCRAM-SHA-1'
+export XRAY_MONGODB_CONN_URL='mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@custom-mongodb.local:27017/?authSource=${MONGODB_DATABASE}&authMechanism=SCRAM-SHA-1'
 helm install -n xray \
     --set mongodb.enabled=false \
-    --set global.mongoUrl=${XRAY_MONGODB_CONN_URL} \
+    --set global.mongoUrl="${XRAY_MONGODB_CONN_URL}" \
     jfrog/xray
 ```
 
@@ -165,7 +165,7 @@ For this, pass the parameters: `postgresql.enabled=false` and `global.postgresql
 export XRAY_POSTGRESQL_CONN_URL='postgres://${POSTGRESQL_USER}:${POSTGRESQL_PASSWORD}@custom-postgresql.local:5432/${POSTGRESQL_DATABASE}?sslmode=disable'
 helm install -n xray \
     --set postgresql.enabled=false \
-    --set global.postgresqlUrl=${XRAY_POSTGRESQL_CONN_URL} \
+    --set global.postgresqlUrl="${XRAY_POSTGRESQL_CONN_URL}" \
     jfrog/xray
 ```
 

--- a/stable/xray/templates/xray-setup-conf.yaml
+++ b/stable/xray/templates/xray-setup-conf.yaml
@@ -52,7 +52,7 @@ data:
 
     # Creating Mongodb URL
     {{- if .Values.mongodb.enabled }}
-    MONGODB_URL="mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@{{ .Release.Name }}-mongodb:27017/?authSource=${MONGODB_DATABASE}\&authMechanism=SCRAM-SHA-1"
+    MONGODB_URL="mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@{{ .Release.Name }}-mongodb:27017/?authSource=${MONGODB_DATABASE}&authMechanism=SCRAM-SHA-1"
     {{- else }}
     MONGODB_URL="${MONGODB_URL}"
     {{- end }}
@@ -73,21 +73,16 @@ data:
     {{- end }}
     cp -vf ${SCRIPTS_DIR}/xray_config.yaml ${XRAY_CONFIG_FILE}
 
-    # Preparing xray_config.yaml
-    sed -i "s RABBITMQ_URL ${RABBITMQ_URL} " ${XRAY_CONFIG_FILE}
-    sed -i "s MONGODB_URL ${MONGODB_URL} " ${XRAY_CONFIG_FILE}
-    sed -i "s POSTGRES_URL ${POSTGRES_URL} " ${XRAY_CONFIG_FILE}
+    echo "mqBaseUrl: \"${RABBITMQ_URL}\""     >> ${XRAY_CONFIG_FILE}
+    echo "mongoUrl: \"${MONGODB_URL}\""       >> ${XRAY_CONFIG_FILE}
+    echo "postgresqlUrl: \"${POSTGRES_URL}\"" >> ${XRAY_CONFIG_FILE}
 
   xray_config.yaml: |
     # Generated Xray config
     ---
     ver:            1.0
-    mqBaseUrl:      "RABBITMQ_URL"
-    mongoUrl:       "MONGODB_URL"
-    postgresqlUrl:  "POSTGRES_URL"
     XrayServerPort: "{{ .Values.server.internalPort }}"
     skipEntLicCheckForCloud: true
 {{- with .Values.common.xrayConfig }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-    # End generated config


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md


**What this PR does / why we need it**:
Simplify the preparation of `xray_config.yaml` in the setup.sh.
`sed` has issues with ampersand, which require escaping. For externally provided connection strings, this might cause confusion for a customer with an external DB.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #326 


**Special notes for your reviewer**:
Functionality with Azure will be tested separately by @nimerb .
