### PR TITLE
Adding custom volume mounts

### DIFF
--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.0] - May 10, 2019
+* Added support for `missionControl.customVolumeMounts` and `missionControl.customEmptyDirMounts` to create custom volume mounts
+
 ## [1.0.6] - Apr 17, 2019
 * Update Mission-Control version to 3.5.2
 

--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [1.1.0] - May 10, 2019
-* Added support for `missionControl.customVolumeMounts` and `missionControl.customEmptyDirMounts` to create custom volume mounts
+* Added support for `missionControl.customVolumeMounts` and `missionControl.customVolumes` to create custom volume mounts
 
 ## [1.0.6] - Apr 17, 2019
 * Update Mission-Control version to 3.5.2

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 description: A Helm chart for JFrog Mission Control
-version: 1.0.6
+version: 1.1.0
 appVersion: 3.5.2
 home: https://jfrog.com/mission-control/
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png

--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -228,20 +228,20 @@ missionControl:
 ### Custom volumes
 There are also cases where you'd like custom files or for your init container to make changes to the file system the mission control container will see.
 
-Two sections exist to allow for custom volume mounts using either an emptyDir volume or an existing PVC in the [vaules.yaml](values.yaml).  By default they are left empty.
+For this, there is a section for defining custom volumes in the [vaules.yaml](values.yaml).  By default they are left empty.
 ```
 missionControl:
-  ## Add custom volume mounts
-  customVolumeMounts: []
-  #  - name: extra-volume
-  #    mountPath: /mnt/volume
-  #    readOnly: true
-  #    existingClaim: volume-claim
+  ## Add custom volumes
+  customVolumes: |
+  #  - name: custom-script
+  #    configMap:
+  #      name: custom-script
 
-  ## Add custom empty dir mounts
-  customEmptyDirMounts: []
-  #  - name: "my-empty-dir"
-  #    mountPath: /opt/my-empty-dir
+  ## Add custom volumeMounts
+  customVolumeMounts: |
+  #  - name: custom-script
+  #    mountPath: "/scripts/script.sh"
+  #    subPath: script.sh
 ```
 
 ## Configuration

--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -225,6 +225,25 @@ missionControl:
     ## Init containers template goes here ##
 ```
 
+### Custom volumes
+There are also cases where you'd like custom files or for your init container to make changes to the file system the mission control container will see.
+
+Two sections exist to allow for custom volume mounts using either an emptyDir volume or an existing PVC in the [vaules.yaml](values.yaml).  By default they are left empty.
+```
+missionControl:
+  ## Add custom volume mounts
+  customVolumeMounts: []
+  #  - name: extra-volume
+  #    mountPath: /mnt/volume
+  #    readOnly: true
+  #    existingClaim: volume-claim
+
+  ## Add custom empty dir mounts
+  customEmptyDirMounts: []
+  #  - name: "my-empty-dir"
+  #    mountPath: /opt/my-empty-dir
+```
+
 ## Configuration
 The following table lists the configurable parameters of the mission-control chart and their default values.
 

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -449,6 +449,16 @@ spec:
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
+      {{- range .Values.missionControl.customVolumeMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          subPath: {{ .subPath | default "" }}
+          readOnly: {{ .readOnly }}
+      {{- end }}
+      {{- range .Values.missionControl.customEmptyDirMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+      {{- end }}
         resources:
 {{ toYaml .Values.missionControl.resources | indent 10 }}
         livenessProbe:
@@ -720,6 +730,15 @@ spec:
       - name: elasticsearch-scripts
         configMap:
           name: {{ template "mission-control.fullname" . }}-elasticsearch-scripts
+    {{- end }}
+    {{- range .Values.missionControl.customVolumeMounts }}
+      - name: {{ .name }}
+        persistentVolumeClaim:
+          claimName: {{ .existingClaim }}
+    {{- end }}
+    {{- range .Values.missionControl.customEmptyDirMounts }}
+      - name: {{ .name }}
+        emptyDir: {}
     {{- end }}
   {{- if not .Values.missionControl.persistence.enabled }}
       - name: mission-control-data

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -449,15 +449,8 @@ spec:
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
-      {{- range .Values.missionControl.customVolumeMounts }}
-        - name: {{ .name }}
-          mountPath: {{ .mountPath }}
-          subPath: {{ .subPath | default "" }}
-          readOnly: {{ .readOnly }}
-      {{- end }}
-      {{- range .Values.missionControl.customEmptyDirMounts }}
-        - name: {{ .name }}
-          mountPath: {{ .mountPath }}
+      {{- if .Values.missionControl.customVolumeMounts }}
+{{ tpl .Values.missionControl.customVolumeMounts . | indent 8 }}
       {{- end }}
         resources:
 {{ toYaml .Values.missionControl.resources | indent 10 }}
@@ -731,14 +724,8 @@ spec:
         configMap:
           name: {{ template "mission-control.fullname" . }}-elasticsearch-scripts
     {{- end }}
-    {{- range .Values.missionControl.customVolumeMounts }}
-      - name: {{ .name }}
-        persistentVolumeClaim:
-          claimName: {{ .existingClaim }}
-    {{- end }}
-    {{- range .Values.missionControl.customEmptyDirMounts }}
-      - name: {{ .name }}
-        emptyDir: {}
+    {{- if .Values.missionControl.customVolumes }}
+{{ tpl .Values.missionControl.customVolumes . | indent 6 }}
     {{- end }}
   {{- if not .Values.missionControl.persistence.enabled }}
       - name: mission-control-data

--- a/stable/mission-control/values.yaml
+++ b/stable/mission-control/values.yaml
@@ -249,6 +249,18 @@ missionControl:
   #      - mountPath: "{{ .Values.missionControl.persistence.mountPath }}"
   #        name: mission-control-data
 
+  ## Add custom volume mounts
+  customVolumeMounts: []
+  #  - name: extra-volume
+  #    mountPath: /mnt/volume
+  #    readOnly: true
+  #    existingClaim: volume-claim
+
+  ## Add custom empty dir mounts
+  customEmptyDirMounts: []
+  #  - name: "my-empty-dir"
+  #    mountPath: /opt/my-empty-dir
+
   ## Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
   loggers: []
   # - audit.log

--- a/stable/mission-control/values.yaml
+++ b/stable/mission-control/values.yaml
@@ -249,17 +249,17 @@ missionControl:
   #      - mountPath: "{{ .Values.missionControl.persistence.mountPath }}"
   #        name: mission-control-data
 
-  ## Add custom volume mounts
-  customVolumeMounts: []
-  #  - name: extra-volume
-  #    mountPath: /mnt/volume
-  #    readOnly: true
-  #    existingClaim: volume-claim
+  ## Add custom volumes
+  customVolumes: |
+  #  - name: custom-script
+  #    configMap:
+  #      name: custom-script
 
-  ## Add custom empty dir mounts
-  customEmptyDirMounts: []
-  #  - name: "my-empty-dir"
-  #    mountPath: /opt/my-empty-dir
+  ## Add custom volumeMounts
+  customVolumeMounts: |
+  #  - name: custom-script
+  #    mountPath: "/scripts/script.sh"
+  #    subPath: script.sh
 
   ## Add any of the loggers to a sidecar if you want to be able to see them with kubectl logs or a log collector in your k8s cluster
   loggers: []


### PR DESCRIPTION
Signed-off-by: Kyle von Bredow <kylevonbredow@gmail.com>

#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds support for custom volumes to be mounted into the mission control container.  This will allow the custom init containers to modify the filesystem before mission control runs.  For example, we can add an enterprise CA into the trusted root store, so that mission control can sync to an internally hosted git repository.

