### PR TITLE
mongoDB resources documentation

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.12.13] - June 20, 2019
+* Document the mongoDB resources values suggestion 
+
 ## [0.12.12] - June 17, 2019
 * Optional support for PostgreSQL with TLS
 

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -18,6 +18,7 @@ This chart will do the following:
 - A running Artifactory
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed and setup to use the cluster
 - [Helm](https://helm.sh/) installed and setup to use the cluster (helm init)
+- mongoDB with enough resources, see suggested values in values.yaml file
 
 
 ## Install JFrog Xray

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -145,16 +145,18 @@ mongodb:
   persistence:
     size: 50Gi
   resources: {}
+  # The following values are suggested to be used when working with mongoDB and Xray. The DB sync in Xray needs more resources than the defaults in mongoDB.
   #  requests:
-  #    memory: "12Gi"
-  #    cpu: "200m"
+  #    memory: "6Gi"
+  #    cpu: "2"
   #  limits:
-  #    memory: "12Gi"
+  #    memory: "6Gi"
   #    cpu: "2"
   ## Make sure the limits.memory value is the same as the requests.memory value!
   ## Make sure the --wiredTigerCacheSizeGB is no more than half the memory limit!
   ## This is critical to protect against OOMKill by Kubernetes!
   mongodbExtraFlags:
+  #The wiredTiger is suggested to be set to 3GB.
   - "--wiredTigerCacheSizeGB=1"
   mongodbRootPassword:
   mongodbUsername: xray


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

The embedded mongoDB starts with the default values inherited from the mongoDB chart which has the resources values of (CPU 100m and Memory 250Mi) and (--wiredTigerCacheSizeGB=1) these values will hung mongoDB and the Xray DB sync will error which causes the Xray server pod to crash.
The PR is to suggest resources values that the users can use.

