### PR TITLE
option to add IP in access.creds

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.15.3] - Jun 23, 2019
+* Add the option to provide an IP for the access-admin endpoints
+
 ## [7.15.2] - Jun 20, 2019
 * Add missing terminationGracePeriodSeconds to values.yaml
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.15.2
+version: 7.15.3
 appVersion: 6.10.4
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -286,6 +286,28 @@ So in order to connect to Artifactory with jconsole you should map the Artifacto
 jconsole artifactory-<release-name>:<jmx-port>
 ```
 
+### Access creds. bootstraping
+**IMPORTANT:** Bootsrapping access creds. would require Artifactory pod restart which by default will generate a random DB password if the password was not provided on initial setup.
+
+* User guide to [bootstrap Artifactory Access credentials](https://www.jfrog.com/confluence/display/ACC/Configuring+Access)
+
+1. Create `access-creds-values.yaml` and provide the IP (By default 127.0.0.1) and password:
+```
+artifactory:
+   accessAdmin:
+    ip: "<IP_RANGE>" #Example: "10.13.89.*"
+    password: "<PASSWD>"
+
+#Need to provide the DB password for the change since db.properties file will get deleted upon every Artifactory startup.
+postgresql:
+  postgresPassword: "<DB_PASSWD>"
+```
+
+2. Apply the `access-creds-values.yaml` file:
+
+ `helm upgrade <helm_release_name> --install jfrog/artifactory -f access-creds-values.yaml`
+ 
+3. Restart Artifactory Pod (`Kubectl delete pod <pod_name>`)
 
 ### Bootstrapping Artifactory
 **IMPORTANT:** Bootstrapping Artifactory needs license. Pass license as shown in above section.
@@ -534,6 +556,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 10 |
 | `artifactory.masterKey`                          | master.key to be used on bootstrap | `FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 | `artifactory.masterKeySecretName`                | Artifactory Master Key secret name |                                                                    |
+| `artifactory.accessAdmin.ip`                     | Artifactory access-admin ip to be set upon startup, can use (*) for 0.0.0.0| 127.0.0.1                                    |
 | `artifactory.accessAdmin.password`               | Artifactory access-admin password to be set upon startup|                                               |
 | `artifactory.accessAdmin.secret`                 | Artifactory access-admin secret name |                                                                    |
 | `artifactory.accessAdmin.dataKey`                | Artifactory access-admin secret data key |                                                                    |

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -287,7 +287,7 @@ jconsole artifactory-<release-name>:<jmx-port>
 ```
 
 ### Access creds. bootstraping
-**IMPORTANT:** Bootsrapping access creds. would require Artifactory pod restart which by default will generate a random DB password if the password was not provided on initial setup.
+**IMPORTANT:** Bootsrapping access creds. will allow access for the user access-admin from certain IP's.
 
 * User guide to [bootstrap Artifactory Access credentials](https://www.jfrog.com/confluence/display/ACC/Configuring+Access)
 
@@ -298,7 +298,6 @@ artifactory:
     ip: "<IP_RANGE>" #Example: "10.13.89.*"
     password: "<PASSWD>"
 
-#Need to provide the DB password for the change since db.properties file will get deleted upon every Artifactory startup.
 postgresql:
   postgresPassword: "<DB_PASSWD>"
 ```

--- a/stable/artifactory/templates/access-bootstrap-creds.yaml
+++ b/stable/artifactory/templates/access-bootstrap-creds.yaml
@@ -10,8 +10,8 @@ metadata:
     release: {{ .Release.Name }}
 data:
 {{- if .Values.artifactory.accessAdmin.password }}
-  bootstrap.creds: {{ (printf "access-admin@127.0.0.1=%s" .Values.artifactory.accessAdmin.password) | b64enc }}
+  bootstrap.creds: {{ (printf "access-admin@%s=%s" .Values.artifactory.accessAdmin.ip .Values.artifactory.accessAdmin.password) | b64enc }}
 {{- else }}
-  bootstrap.creds: {{ (printf "access-admin@127.0.0.1=%s" (randAlphaNum 10)) | b64enc }}
+  bootstrap.creds: {{ (printf "access-admin@%s=%s" .Values.artifactory.accessAdmin.ip (randAlphaNum 10)) | b64enc }}
 {{- end }}
 {{- end }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -212,6 +212,7 @@ artifactory:
 
   # accessAdmin is the password used for the access-admin user: https://jfrog.com/knowledge-base/how-to-change-the-default-password-for-access-admin-user/
   accessAdmin:
+    ip: "127.0.0.1"
     password:
     secret:
     dataKey:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

Enable the option to add certain IP's that are able to access the access-admin endpoints, where by default only localhost can access with the mentioned user (access-admin).


