### PR TITLE
Add the option to provide an IP for the access-admin endpoints

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.14.3] - Jun 24, 2019
+* Add the option to provide an IP for the access-admin endpoints
+
 ## [0.14.2] - Jun 24, 2019
 * Change Nginx to point to the artifactory externalPort
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.14.2
+version: 0.14.3
 appVersion: 6.10.4
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.14.3
+version: 0.14.4
 appVersion: 6.10.4
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -355,6 +355,26 @@ jconsole artifactory-ha-<release-name>-primary:<primary-jmx-port>
 jconsole <release-name>:<node-jmx-port>
 ```
 
+### Access creds. bootstraping
+**IMPORTANT:** Bootsrapping access creds. will allow access for the user access-admin from certain IP's.
+
+* User guide to [bootstrap Artifactory Access credentials](https://www.jfrog.com/confluence/display/ACC/Configuring+Access)
+
+1. Create `access-creds-values.yaml` and provide the IP (By default 127.0.0.1) and password:
+```
+artifactory:
+   accessAdmin:
+    ip: "<IP_RANGE>" #Example: "10.13.89.*"
+    password: "<PASSWD>"
+
+postgresql:
+  postgresPassword: "<DB_PASSWD>"
+```
+
+2. Apply the `access-creds-values.yaml` file:
+
+ `helm upgrade <helm_release_name> --install jfrog/artifactory-ha -f access-creds-values.yaml`
+
 ### Bootstrapping Artifactory
 **IMPORTANT:** Bootstrapping Artifactory needs license. Pass license as shown in above section.
 
@@ -622,6 +642,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.userPluginSecrets`   | Array of secret names for Artifactory user plugins |                                 |
 | `artifactory.masterKey`           | Artifactory Master Key. Can be generated with `openssl rand -hex 32` |`FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF`|
 | `artifactory.masterKeySecretName` | Artifactory Master Key secret name                     |                             |
+| `artifactory.accessAdmin.ip`                     | Artifactory access-admin ip to be set upon startup, can use (*) for 0.0.0.0| 127.0.0.1                                    |
 | `artifactory.accessAdmin.password`               | Artifactory access-admin password to be set upon startup|             |
 | `artifactory.accessAdmin.secret`                 | Artifactory access-admin secret name |                                |
 | `artifactory.accessAdmin.dataKey`                | Artifactory access-admin secret data key |                            |

--- a/stable/artifactory-ha/templates/access-bootstrap-creds.yaml
+++ b/stable/artifactory-ha/templates/access-bootstrap-creds.yaml
@@ -10,8 +10,8 @@ metadata:
     release: {{ .Release.Name }}
 data:
 {{- if .Values.artifactory.accessAdmin.password }}
-  bootstrap.creds: {{ (printf "access-admin@127.0.0.1=%s" .Values.artifactory.accessAdmin.password) | b64enc }}
+   bootstrap.creds: {{ (printf "access-admin@%s=%s" .Values.artifactory.accessAdmin.ip .Values.artifactory.accessAdmin.password) | b64enc }}
 {{- else }}
-  bootstrap.creds: {{ (printf "access-admin@127.0.0.1=%s" (randAlphaNum 10)) | b64enc }}
+   bootstrap.creds: {{ (printf "access-admin@%s=%s" .Values.artifactory.accessAdmin.ip (randAlphaNum 10)) | b64enc }}
 {{- end }}
 {{- end }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -243,6 +243,7 @@ artifactory:
   # masterKeySecretName:
 
   accessAdmin:
+    ip: "127.0.0.1"
     password:
     secret:
     dataKey:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Enable the option to add certain IP's that are able to access the access-admin endpoints, where by default only localhost can access with the mentioned user (access-admin).

