### PR TITLE
Restart Primary node when bootstrap.creds file has been modified in a…

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.14.5] - Jun 27, 2019
+* Restart Primary node when bootstrap.creds file has been modified in artifactory-ha
+
 ## [0.14.4] - Jun 24, 2019
 * Add the option to provide an IP for the access-admin endpoints
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.14.4
+version: 0.14.5
 appVersion: 6.10.4
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -364,7 +364,7 @@ jconsole <release-name>:<node-jmx-port>
 ```
 artifactory:
    accessAdmin:
-    ip: "<IP_RANGE>" #Example: "10.13.89.*"
+    ip: "<IP_RANGE>" #Example: "*"
     password: "<PASSWD>"
 
 postgresql:

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -29,6 +29,7 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/binarystore: {{ include (print $.Template.BasePath "/artifactory-binarystore.yaml") . | sha256sum }}
+        checksum/access-creds: {{ include (print $.Template.BasePath "/access-bootstrap-creds.yaml") . | sha256sum }}
       {{- range $key, $value := .Values.artifactory.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}


### PR DESCRIPTION
…rtifactory-ha

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Since the bootstrap.creds is loaded only on startup, after applying the bootstap.creds for a running Artifactory, the primary node will do a restart automatically to load the changes.  
