### PR TITLE
Set server and indexer default persistency to true

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,14 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.0] - Jul 9, 2019
+* Set default server and indexer services persistence to `true`.
+* **IMPORTANT:**
+  * To upgrade from a previous Xray deployment, you have to pass the `--force` flag to the `helm upgrade` command.
+  * This is mandatory to force the change services persistence to `true`.
+  * This change will recreate the server and indexer pods!
+  * **NOTE:** Don't forget to pass the DBs passwords to the `helm upgrade` if these were auto generated. See [README.md](README.md) for details in the **Upgrade** section.
+
 ## [0.12.17] - Jul 1, 2019
 * Update Xray version to 2.8.9
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.12.17
+version: 1.0.0
 appVersion: 2.8.9
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -83,7 +83,11 @@ If Xray was installed with all of the default values (e.g. with no user-provided
 1. Retrieve all current passwords (rabbitmq/postgresql/mongodb) as explained in the above section.
 2. Upgrade the release by passing the previously auto-generated secrets:
 ```bash
-helm upgrade --name xray jfrog/xray --set mongodb.mongodbRootPassword=<mongo-root-password> --set mongodb.mongodbPassword=<mongo-password> --set rabbitmq-ha.rabbitmqPassword=<rabbit-password> --set postgresql.postgresPassword=<postgres-password>
+helm upgrade --name xray jfrog/xray \
+    --set mongodb.mongodbRootPassword=${MONGODB_ROOT_PASSWORD} \
+    --set mongodb.mongodbPassword=${MONGODB_PASSWORD} \
+    --set rabbitmq-ha.rabbitmqPassword=${RABBITMQ_PASSWORD} \
+    --set postgresql.postgresPassword=${POSTGRES_PASSWORD}
 ```
 
 ## Remove

--- a/stable/xray/values-large.yaml
+++ b/stable/xray/values-large.yaml
@@ -66,3 +66,5 @@ indexer:
     limits:
       memory: "2Gi"
       cpu: "2"
+  persistence:
+    size: 500Gi

--- a/stable/xray/values-medium.yaml
+++ b/stable/xray/values-medium.yaml
@@ -66,3 +66,5 @@ indexer:
     limits:
       memory: "2Gi"
       cpu: "1"
+  persistence:
+    size: 200Gi

--- a/stable/xray/values-small.yaml
+++ b/stable/xray/values-small.yaml
@@ -66,3 +66,5 @@ indexer:
     limits:
       memory: "2Gi"
       cpu: "1"
+  persistence:
+    size: 100Gi

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -312,7 +312,7 @@ indexer:
     type: ClusterIP
 
   persistence:
-    enabled: false
+    enabled: true
     ## A manually managed Persistent Volume and Claim
     ## Requires persistence.enabled: true
     ## If defined, PVC must be created manually before volume will be bound
@@ -389,7 +389,7 @@ server:
     # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:XXXXXX:certificate/XXXXXX
 
   persistence:
-    enabled: false
+    enabled: true
     ## A manually managed Persistent Volume and Claim
     ## Requires persistence.enabled: true
     ## If defined, PVC must be created manually before volume will be bound


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Set the default server and indexer default persistency to true to have better stability and reliability of the DB sync and indexing processes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
A `helm upgrade --force` must be used when upgrading.
