### PR TITLE
[artifactory] Add ingress.hosts to the Nginx server_name directive

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.16.3] - Jul 11, 2019
+* Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration 
+
 ## [7.16.2] - Jul 3, 2019
 * Fix values key in reverse proxy example
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.16.2
+version: 7.16.3
 appVersion: 6.11.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -46,8 +46,7 @@ ingress:
   defaultBackend:
     enabled: true
   # Used to create an Ingress record.
-  hosts:
-    - artifactory.domain.example
+  hosts: []
   path: /
   annotations:
   # kubernetes.io/ingress.class: nginx
@@ -481,7 +480,12 @@ nginx:
     server {
       listen {{ .Values.nginx.internalPortHttps }} ssl;
       listen {{ .Values.nginx.internalPortHttp }} ;
-      server_name ~(?<repo>.+)\.{{ include "artifactory.fullname" . }} {{ include "artifactory.fullname" . }};
+      server_name ~(?<repo>.+)\.{{ include "artifactory.fullname" . }} {{ include "artifactory.fullname" . }}
+      {{- range .Values.ingress.hosts -}}
+        {{- if contains "." . -}}
+          {{ "" | indent 0 }} ~(?<repo>.+)\.{{ (splitn "." 2 .)._1  }} {{ . }}
+        {{- end -}}
+      {{- end -}};
 
       if ($http_x_forwarded_proto = '') {
         set $http_x_forwarded_proto  $scheme;


### PR DESCRIPTION
…enabled

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add the ingress.hosts to the nginx server_name directive. This will make sure that the ingress hostnames are able to resolve the repository name from the hostname by the Docker repository sub domain method. This will help users with setting up Docker repository sub domain access without any need to provide a custom values.yaml

