### PR TITLE
Add artifactory.customVolumeMounts to member nodes

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -2,6 +2,9 @@
 All changes to this chart will be documented in this file.
 
 ## [0.15.3] - Jul 11, 2019
+* Add `artifactory.customVolumeMounts` to member node statefulset template
+
+## [0.15.3] - Jul 11, 2019
 * Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration 
 
 ## [0.15.2] - Jul 3, 2019

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [0.15.3] - Jul 11, 2019
-* Add `artifactory.customVolumeMounts` to member node statefulset template
+* Add `artifactory.customVolumeMounts` support to member node statefulset template
 
 ## [0.15.3] - Jul 11, 2019
 * Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration 

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [0.15.3] - Jul 11, 2019
+## [0.15.4] - Jul 11, 2019
 * Add `artifactory.customVolumeMounts` support to member node statefulset template
 
 ## [0.15.3] - Jul 11, 2019

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.15.3
+version: 0.15.4
 appVersion: 6.11.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -302,6 +302,9 @@ spec:
         - name: installer-info
           mountPath: "/artifactory_extra_conf/info/installer-info.json"
           subPath: installer-info.json
+      {{- if .Values.artifactory.customVolumeMounts }}
+{{ tpl .Values.artifactory.customVolumeMounts . | indent 8 }}
+      {{- end }}
         resources:
 {{ toYaml .Values.artifactory.node.resources | indent 10 }}
         {{- if .Values.artifactory.readinessProbe.enabled }}


### PR DESCRIPTION
#### PR Checklist
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

The `artifactory.customVolumeMounts` setting is not currently being applied to the member nodes created by the `artifactory-node-statefulset.yaml` template.  The mounts are only being applied to the primary node.  This adds the mount points to the member nodes as well.