### PR TITLE
Remove beta API groups and choose the Ingress API group depending on …

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.15.5] - Jul 22, 2019
+* Change Ingress API to be compatible with recent kubernetes versions
+
 ## [0.15.4] - Jul 11, 2019
 * Add `artifactory.customVolumeMounts` support to member node statefulset template
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.15.4
+version: 0.15.5
 appVersion: 6.11.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/ingress.yaml
+++ b/stable/artifactory-ha/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "artifactory-ha.fullname" . -}}
 {{- $servicePort := .Values.artifactory.externalPort -}}
+{{- if semverCompare ">=v1.14.0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "artifactory-ha.fullname" . }}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.16.4] - Jul 22, 2019
+* Change Ingress API to be compatible with recent kubernetes versions 
+
 ## [7.16.3] - Jul 11, 2019
 * Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration 
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.16.3
+version: 7.16.4
 appVersion: 6.11.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/ingress.yaml
+++ b/stable/artifactory/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "artifactory.fullname" . -}}
 {{- $servicePort := .Values.artifactory.externalPort -}}
+{{- if semverCompare ">=v1.14.0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "artifactory.fullname" . }}

--- a/stable/distribution/CHANGELOG.md
+++ b/stable/distribution/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Distribution Chart Changelog
 All changes to this project chart be documented in this file.
 
+## [3.3.0] - Jul 22, 2019
+* Change Ingress API to be compatible with recent kubernetes versions
+
 ## [3.2.9] - Jun 30, 2019
 * Update statfulset apiVersion to apps/v1
 

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: distribution
 description: A Helm chart for JFrog Distribution
-version: 3.2.9
+version: 3.3.0
 appVersion: 1.6.1
 home: https://jfrog.com/platform/
 icon: https://raw.githubusercontent.com/jfrog/artifactory-dcos/master/images/jfrog_med.png

--- a/stable/distribution/templates/ingress.yaml
+++ b/stable/distribution/templates/ingress.yaml
@@ -1,7 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "distribution.fullname" . -}}
 {{- $servicePort := .Values.distribution.externalPort -}}
+{{- if semverCompare ">=v1.14.0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
+
 kind: Ingress
 metadata:
   name: {{ template "distribution.fullname" . }}

--- a/stable/kubexray/CHANGELOG.md
+++ b/stable/kubexray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog KubeXray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.3.12]  - Jul 22, 2019
+* Change Ingress API to be compatible with recent kubernetes versions and remove the beta API group from the Deployment
+
 ## [0.3.11]  - June 24, 2019
 * Update chart maintainers
 

--- a/stable/kubexray/Chart.yaml
+++ b/stable/kubexray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubexray
-version: 0.3.11
+version: 0.3.12
 appVersion: 0.1.3
 home: https://github.com/jfrog/kubexray
 description: KubeXray Helm chart

--- a/stable/kubexray/templates/deployment.yaml
+++ b/stable/kubexray/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if or .Values.xrayConfig .Values.existingSecret -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubexray.fullname" . }}

--- a/stable/kubexray/templates/ingress.yaml
+++ b/stable/kubexray/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kubexray.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "kubexray.fullname" . }}

--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.5] - Jul 22, 2019
+* Change Ingress API to be compatible with recent kubernetes versions
+
 ## [1.1.4] - Jun 24, 2019
 * Update chart maintainers
 

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 description: A Helm chart for JFrog Mission Control
-version: 1.1.4
+version: 1.1.5
 appVersion: 3.5.3
 home: https://jfrog.com/mission-control/
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png

--- a/stable/mission-control/templates/ingress.yaml
+++ b/stable/mission-control/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mission-control.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=v1.14.0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.3] - Jul 22, 2019
+* Change Ingress API to be compatible with recent kubernetes versions
+
 ## [1.0.2] - Jul 15, 2019
 * Add the option to provide ingress additional rules
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.8.9
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/templates/ingress.yaml
+++ b/stable/xray/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "xray-server.fullname" . -}}
 {{- $servicePort := .Values.server.externalPort -}}
+{{- if semverCompare ">=v1.14.0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "xray.fullname" . }}

--- a/test/local-path-provisioner.yaml
+++ b/test/local-path-provisioner.yaml
@@ -9,7 +9,7 @@ metadata:
   name: local-path-provisioner-service-account
   namespace: local-path-storage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-path-provisioner-role
@@ -28,7 +28,7 @@ rules:
   resources: ["storageclasses"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-path-provisioner-bind
@@ -42,7 +42,7 @@ subjects:
   name: local-path-provisioner-service-account
   namespace: local-path-storage
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: local-path-provisioner


### PR DESCRIPTION
…the k8s version

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Remove beta API groups and choose the ingress API group based on the k8s version


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #420 

**Special notes for your reviewer**:
@eldada @rimusz :) 

It's hard to test the ingress since GKE has no version over k8s 1.14 but it seems to work
