### PR TITLE
Updated README

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -398,4 +398,7 @@ All changes to this chart will be documented in this file.
 * Added support for PostStartCommand (To download Database JDBC connector)
 * Increased postgresql max_connections
 * Added support for `nginx.conf` ConfigMap
-* Updated Artifactory version to 6.1.0
+*jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=my-artifactory-db;sendStringParametersAbsUnicode=false;applicationName=Artifactory Binary Repository Updated Artifactory version to 6.1.0
+
+## [0.3.1] - Aug 08, 2019
+* Updated README with recommendations

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.15.8
+version: 0.15.9
 appVersion: 6.11.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -35,6 +35,18 @@ To install the chart with the release name `artifactory-ha`:
 helm install --name artifactory-ha jfrog/artifactory-ha
 ```
 
+### Install with External PostgreSQL
+At this time, production-ready Artifactory-HA installations need to use an external PostgreSQL with a static password. This is for performance and stability reasons.
+```bash
+helm install --name artifactory-ha \
+--set postgresql.enabled=false \
+--set database.type=postgresql \
+--set database.url='jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=my-artifactory-db;sendStringParametersAsUnicode=false;applicationName=Artifactory Binary Repository' \
+--set database.user=${DB_USER} \
+--set database.password=${DB_PASSWORD} \
+  jfrog/artifactory-ha
+```
+
 ### Deploying Artifactory with replicator
 The [Artifactory replicator](https://www.jfrog.com/confluence/display/RTF/Replicator) is used with an [Enterprise Plus](https://www.jfrog.com/confluence/display/EP/Welcome+to+JFrog+Enterprise+Plus) license.
 ```bash

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -36,12 +36,13 @@ helm install --name artifactory-ha jfrog/artifactory-ha
 ```
 
 ### Install with External PostgreSQL
-At this time, production-ready Artifactory-HA installations need to use an external PostgreSQL with a static password. This is for performance and stability reasons.
+At this time, for production-ready Artifactory-HA installations it's recommended to use an external PostgreSQL with a static password. This is for performance and stability reasons.
+
 ```bash
 helm install --name artifactory-ha \
 --set postgresql.enabled=false \
 --set database.type=postgresql \
---set database.url='jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=my-artifactory-db;sendStringParametersAsUnicode=false;applicationName=Artifactory Binary Repository' \
+--set database.url='jdbc:postgresql://<Database_URL>:5432/artifactory' \
 --set database.user=${DB_USER} \
 --set database.password=${DB_PASSWORD} \
   jfrog/artifactory-ha

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -369,3 +369,6 @@ All changes to this chart will be documented in this file.
 * Increased postgresql max_connections
 * Added support for `nginx.conf` ConfigMap
 * Updated Artifactory version to 6.1.0
+
+## [7.3.1] - Aug 08, 2019
+* Updated README with Postgre recommendations

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.16.6
+version: 7.16.7
 appVersion: 6.11.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -48,6 +48,19 @@ helm install --name artifactory --set postgresql.enabled=false jfrog/artifactory
 ```
 Artifactory will start with it's embedded Derby database.
 
+### Install with External PostgreSQL
+At this time, for production-ready Artifactory-HA installations it's recommended to use an external PostgreSQL with a static password. This is for performance and stability reasons.
+
+```bash
+helm install --name artifactory-ha \
+--set postgresql.enabled=false \
+--set database.type=postgresql \
+--set database.url='jdbc:postgresql://<Database_URL>:5432/artifactory' \
+--set database.user=${DB_USER} \
+--set database.password=${DB_PASSWORD} \
+  jfrog/artifactory-ha
+```
+
 ### Deploying Artifactory with replicator
 The [Artifactory replicator](https://www.jfrog.com/confluence/display/RTF/Replicator) is used with an [Enterprise Plus](https://www.jfrog.com/confluence/display/EP/Welcome+to+JFrog+Enterprise+Plus) license.
 ```bash


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Updates the README.md for charts/artifactory-ha.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # Fixes a problem with the recommended initial setup of Artifactory-ha that can lead to a non-production ready deployment of the cluster.

The main issue is that running the default "helm install" causes the db password to be reset if it is not pulled during a "helm upgrade". This is already documented in the README, but it is not clearly stated that it is not the best way to set up the cluster.

The change will add a recommendation to the top of the file that recommends using an external Postgres to avoid this problem.


**Special notes for your reviewer**:

