### PR TITLE
Fix masterKey warning render logic in NOTES.txt

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.15.9] - Aug 1, 2019
+* Fix masterkey/masterKeySecretName not specified warning render logic in NOTES.txt
+
 ## [0.15.8] - Jul 28, 2019
 * Simplify nginx setup and shorten initial wait for probes 
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.15.8
+version: 0.15.9
 appVersion: 6.11.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/NOTES.txt
+++ b/stable/artifactory-ha/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Congratulations. You have just deployed JFrog Artifactory HA!
 
-{{- if (not .Values.artifactory.masterKeySecretName) and eq .Values.artifactory.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" }}
+{{- if and (not .Values.artifactory.masterKeySecretName) (eq .Values.artifactory.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") }}
 
 
 ***************************************** WARNING ******************************************


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
Even when masterKey or masterKeySecretName is specified, 
```
***************************************** WARNING ******************************************
* Your Artifactory master key is still set to the provided example:                        *
* artifactory.masterKey=FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF   *
*                                                                                          *
* You should change this to your own generated key:                                        *
* $ export MASTER_KEY=$(openssl rand -hex 32)                                              *
* $ echo ${MASTER_KEY}                                                                     *
*                                                                                          *
* Pass the created master key to helm with '--set artifactory.masterKey=${MASTER_KEY}'     *
*                                                                                          *
* Alternatively, you can use a pre-existing secret with a key called master-key with       *
* '--set artifactory.masterKeySecretName=${SECRET_NAME}'                                   *
********************************************************************************************
```
is rendered while doing `helm template . --notes`

This PR fixes the logic for generating that warning which is very misleading.
