### PR TITLE
enabling cache dir as a secondary FS mount

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,5 +1,7 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
+## [7.18.0] - Sep 17, 2019
+* Enabled configuring cache as a secondary disk mount
 
 ## [7.17.4] - Sep 11, 2019
 * Updated Artifactory version to 6.12.2

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.17.4
+version: 7.18.0
 appVersion: 6.12.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -119,15 +119,17 @@ To use an NFS server as your cluster's storage, you need to
 ...
 ```
 
-To enable a second volume for cache storage: 
+Sometimes enabling a second volume for cache storage is desirable. This is useful so that you can put your primary storage on a slower (cheaper) medium while the cache is on a faster (more expensive) medium.
+
+The following shows which parameters to set in order to enable the cache volume:
 ```bash
 ...
 --set artifactory.persistence.cacheFs.enabled=true \
 --set artifactory.persistence.cacheFs.mountPath=/jfrog/cache \
 --set artifactory.persistence.cacheFs.storageClass=your-class-name \
 ```
+This is useful so that you can put your primary storage on a slower (cheaper) medium while the cache is on a faster (more expensive) medium
 
-This will allow you to mount a faster disk volume to use as cache.
 
 #### Google Storage
 To use a Google Storage bucket as the cluster's filestore. See [Google Storage Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-GoogleStorageBinaryProvider)
@@ -629,9 +631,10 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.customBinarystoreXmlSecret` | A custom Secret for binarystore.xml  | ``                                   |
 | `artifactory.persistence.maxCacheSize`   | The maximum storage allocated for the cache in bytes. | `50000000000`                   |
 | `artifactory.persistence.cacheFs.enabled` | Enabled a cache persistent volume | `false` |
-| `artifactory.persistence.cacheFs.persistence.accessMode` | Access mode for the cache persistent volume | `ReadWriteOnce`         |
-| `artifactory.persistence.cacheFs.persistence.bytes`      | Desired size in bytes of the persistent volume | `182536110080`       |
-| `artifactory.persistence.cacheFs.persistence.mountPath`  | Location on the filesystem to mount the cache volume | `/jfrog/cache` |
+| `artifactory.persistence.cacheFs.persistence.accessMode`         | Access mode for the cache persistent volume | `ReadWriteOnce`         |
+| `artifactory.persistence.cacheFs.persistence.bytes`              | Desired size in bytes of the persistent volume | `60000000000`        |
+| `artifactory.persistence.cacheFs.persistence.mountPath`          | Location on the filesystem to mount the cache volume | `/jfrog/cache` |
+| `artifactory.persistence.cacheFs.persistence.storageClass.bytes` | Storageclass of the persistent volume | See `values.yaml`             |
 | `artifactory.persistence.type`              | Artifactory HA storage type                         | `file-system`                   |
 | `artifactory.persistence.redundancy`        | Artifactory HA storage redundancy                   | `3`                             |
 | `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -618,7 +618,10 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.binarystoreXml` | Artifactory binarystore.xml template             | See `values.yaml`                    |
 | `artifactory.persistence.customBinarystoreXmlSecret` | A custom Secret for binarystore.xml  | ``                                   |
 | `artifactory.persistence.maxCacheSize`   | The maximum storage allocated for the cache in bytes. | `50000000000`                   |
-| `artifactory.persistence.cacheProviderDir`  | the root folder of binaries for the filestore cache. If the value specified starts with a forward slash ("/") it is considered the fully qualified path to the filestore folder. Otherwise, it is considered relative to the *baseDataDir*. | `cache`                   |
+| `artifactory.cacheFs.enabled` | Enabled a cache persistent volume | `false` |
+| `artifactory.cacheFs.persistence.accessMode` | Access mode for the cache persistent volume | `ReadWriteOnce`         |
+| `artifactory.cacheFs.persistence.bytes`      | Desired size in bytes of the persistent volume | `182536110080`       |
+| `artifactory.cacheFs.persistence.mountPath`  | Location on the filesystem to mount the cache volume | `/jfrog/cache` |
 | `artifactory.persistence.type`              | Artifactory HA storage type                         | `file-system`                   |
 | `artifactory.persistence.redundancy`        | Artifactory HA storage redundancy                   | `3`                             |
 | `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -618,10 +618,10 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.persistence.binarystoreXml` | Artifactory binarystore.xml template             | See `values.yaml`                    |
 | `artifactory.persistence.customBinarystoreXmlSecret` | A custom Secret for binarystore.xml  | ``                                   |
 | `artifactory.persistence.maxCacheSize`   | The maximum storage allocated for the cache in bytes. | `50000000000`                   |
-| `artifactory.cacheFs.enabled` | Enabled a cache persistent volume | `false` |
-| `artifactory.cacheFs.persistence.accessMode` | Access mode for the cache persistent volume | `ReadWriteOnce`         |
-| `artifactory.cacheFs.persistence.bytes`      | Desired size in bytes of the persistent volume | `182536110080`       |
-| `artifactory.cacheFs.persistence.mountPath`  | Location on the filesystem to mount the cache volume | `/jfrog/cache` |
+| `artifactory.persistence.cacheFs.enabled` | Enabled a cache persistent volume | `false` |
+| `artifactory.persistence.cacheFs.persistence.accessMode` | Access mode for the cache persistent volume | `ReadWriteOnce`         |
+| `artifactory.persistence.cacheFs.persistence.bytes`      | Desired size in bytes of the persistent volume | `182536110080`       |
+| `artifactory.persistence.cacheFs.persistence.mountPath`  | Location on the filesystem to mount the cache volume | `/jfrog/cache` |
 | `artifactory.persistence.type`              | Artifactory HA storage type                         | `file-system`                   |
 | `artifactory.persistence.redundancy`        | Artifactory HA storage redundancy                   | `3`                             |
 | `artifactory.persistence.nfs.ip`            | NFS server IP                        |                                     |

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -119,6 +119,16 @@ To use an NFS server as your cluster's storage, you need to
 ...
 ```
 
+To enable a second volume for cache storage: 
+```bash
+...
+--set artifactory.persistence.cacheFs.enabled=true \
+--set artifactory.persistence.cacheFs.mountPath=/jfrog/cache \
+--set artifactory.persistence.cacheFs.storageClass=your-class-name \
+```
+
+This will allow you to mount a faster disk volume to use as cache.
+
 #### Google Storage
 To use a Google Storage bucket as the cluster's filestore. See [Google Storage Binary Provider](https://www.jfrog.com/confluence/display/RTF/Configuring+the+Filestore#ConfiguringtheFilestore-GoogleStorageBinaryProvider)
 - Pass Google Storage parameters to `helm install` and `helm upgrade`

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -71,7 +71,7 @@ spec:
           mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
         {{- if .Values.artifactory.persistence.cacheFs.enabled }}
         - name: artifactory-cachefs-volume
-          mountPath: "{{ .Values.artifactory.cacheFs.persistence.mountPath }}"
+          mountPath: "{{ .Values.artifactory.persistence.cacheFs.persistence.mountPath }}"
         {{- end }}
     {{- end }}
     {{- if or (and .Values.artifactory.accessAdmin.secret .Values.artifactory.accessAdmin.dataKey) .Values.artifactory.accessAdmin.password }}

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -69,6 +69,16 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
+        {{- if .Values.artifactory.cacheFs.enabled }}
+        - name: artifactory-cachefs-volume
+          mountPath: "{{ .Values.artifactory.cacheFs.persistence.mountPath }}"
+        {{- end }}
+      {{- if eq .Values.artifactory.persistence.type "nfs" }}
+        - name: artifactory-data
+          mountPath: "{{ .Values.artifactory.persistence.nfs.dataDir }}"
+        - name: artifactory-backup
+          mountPath: "{{ .Values.artifactory.persistence.nfs.backupDir }}"
+      {{- end }}
     {{- end }}
     {{- if or (and .Values.artifactory.accessAdmin.secret .Values.artifactory.accessAdmin.dataKey) .Values.artifactory.accessAdmin.password }}
       - name: "access-bootstrap-creds"
@@ -461,5 +471,26 @@ spec:
       resources:
         requests:
           storage: {{ .size }}
+      {{- end }}
+      {{- else }}
+      - name: artifactory-volume
+        emptyDir:
+          sizeLimit: {{ .size }}
+      {{- end }}
+  {{- if .Values.artifactory.cacheFs.enabled }}
+  - metadata:
+      name: artifactory-cachefs-volume
+    spec:
+      {{- if .Values.artifactory.cacheFs.persistence.storageClass }}
+      {{- if (eq "-" .Values.artifactory.cacheFs.persistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: "{{ .Values.artifactory.cacheFs.persistence.storageClass }}"
+      {{- end }}
+      {{- end }}
+      accessModes: [ "{{ .Values.artifactory.cacheFs.persistence.accessMode }}" ]
+      resources:
+        requests:
+          {{- $cacheBytes := add .Values.artifactory.cacheFs.persistence.bytes 1073741824 }}
+          storage: {{ div $cacheBytes 1073741824 }}Gi
   {{- end }}
-{{- end }}

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -73,12 +73,6 @@ spec:
         - name: artifactory-cachefs-volume
           mountPath: "{{ .Values.artifactory.cacheFs.persistence.mountPath }}"
         {{- end }}
-      {{- if eq .Values.artifactory.persistence.type "nfs" }}
-        - name: artifactory-data
-          mountPath: "{{ .Values.artifactory.persistence.nfs.dataDir }}"
-        - name: artifactory-backup
-          mountPath: "{{ .Values.artifactory.persistence.nfs.backupDir }}"
-      {{- end }}
     {{- end }}
     {{- if or (and .Values.artifactory.accessAdmin.secret .Values.artifactory.accessAdmin.dataKey) .Values.artifactory.accessAdmin.password }}
       - name: "access-bootstrap-creds"

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
-        {{- if .Values.artifactory.cacheFs.enabled }}
+        {{- if .Values.artifactory.persistence.cacheFs.enabled }}
         - name: artifactory-cachefs-volume
           mountPath: "{{ .Values.artifactory.cacheFs.persistence.mountPath }}"
         {{- end }}
@@ -471,26 +471,26 @@ spec:
       resources:
         requests:
           storage: {{ .size }}
-      {{- end }}
-      {{- else }}
+  {{- else }}
       - name: artifactory-volume
         emptyDir:
           sizeLimit: {{ .size }}
-      {{- end }}
-  {{- if .Values.artifactory.cacheFs.enabled }}
+  {{- end }}
+  {{- if .cacheFs.enabled }}
   - metadata:
       name: artifactory-cachefs-volume
     spec:
-      {{- if .Values.artifactory.cacheFs.persistence.storageClass }}
-      {{- if (eq "-" .Values.artifactory.cacheFs.persistence.storageClass) }}
+      {{- if .cacheFs.persistence.storageClass }}
+      {{- if (eq "-" .cacheFs.persistence.storageClass) }}
       storageClassName: ""
       {{- else }}
-      storageClassName: "{{ .Values.artifactory.cacheFs.persistence.storageClass }}"
+      storageClassName: "{{ .cacheFs.persistence.storageClass }}"
       {{- end }}
       {{- end }}
-      accessModes: [ "{{ .Values.artifactory.cacheFs.persistence.accessMode }}" ]
+      accessModes: [ "{{ .cacheFs.persistence.accessMode }}" ]
       resources:
         requests:
-          {{- $cacheBytes := add .Values.artifactory.cacheFs.persistence.bytes 1073741824 }}
+          {{- $cacheBytes := add .cacheFs.persistence.bytes 1073741824 }}
           storage: {{ div $cacheBytes 1073741824 }}Gi
   {{- end }}
+{{- end }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -272,13 +272,6 @@ artifactory:
     periodSeconds: 10
     successThreshold: 1
 
-  cacheFs:
-    enabled: false
-    persistence:
-      accessMode: ReadWriteOnce
-      bytes: 182536110080
-      mountPath: /jfrog/cache
-
   persistence:
     mountPath: "/var/opt/jfrog/artifactory"
     enabled: true
@@ -296,6 +289,14 @@ artifactory:
 
     maxCacheSize: 50000000000
     cacheProviderDir: cache
+    cacheFs:
+      enabled: false
+      persistence:
+        accessMode: ReadWriteOnce
+        bytes: 60000000000
+        mountPath: /jfrog/cache
+
+
 
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:
@@ -313,10 +314,10 @@ artifactory:
       <!-- File system filestore -->
       <config version="v2">
           <chain template="file-system"/>
-          {{- if .Values.artifactory.cacheFs.enabled }}
+          {{- if .Values.artifactory.persistence.cacheFs.enabled }}
           <provider id="cache-fs" type="cache-fs">
-              <cacheProviderDir>{{ .Values.artifactory.cacheFs.persistence.mountPath }}</cacheProviderDir>
-              <maxCacheSize>{{ .Values.artifactory.cacheFs.persistence.bytes }}</maxCacheSize>
+              <cacheProviderDir>{{ .Values.artifactory.persistence.cacheFs.persistence.mountPath }}</cacheProviderDir>
+              <maxCacheSize>{{ .Values.artifactory.persistence.cacheFs.persistence.bytes }}</maxCacheSize>
           </provider>
           {{- end }}
       </config>

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -295,6 +295,8 @@ artifactory:
     customBinarystoreXmlSecret:
 
     maxCacheSize: 50000000000
+    cacheProviderDir: cache
+
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:
     ## file-system (default)

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -273,7 +273,7 @@ artifactory:
     successThreshold: 1
 
   cacheFs:
-    enabled: true
+    enabled: false
     persistence:
       accessMode: ReadWriteOnce
       bytes: 182536110080

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -295,6 +295,14 @@ artifactory:
         accessMode: ReadWriteOnce
         bytes: 60000000000
         mountPath: /jfrog/cache
+        ## artifactory cache Persistent Volume Storage Class
+        ## If defined, storageClassName: <storageClass>
+        ## If set to "-", storageClassName: "", which disables dynamic provisioning
+        ## If undefined (the default) or set to null, no storageClassName spec is
+        ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+        ##   GKE, AWS & OpenStack)
+        ##
+        # storageClass: "-"
 
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -296,8 +296,6 @@ artifactory:
         bytes: 60000000000
         mountPath: /jfrog/cache
 
-
-
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:
     ## file-system (default)

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -271,6 +271,14 @@ artifactory:
     timeoutSeconds: 10
     periodSeconds: 10
     successThreshold: 1
+
+  cacheFs:
+    enabled: true
+    persistence:
+      accessMode: ReadWriteOnce
+      bytes: 182536110080
+      mountPath: /jfrog/cache
+
   persistence:
     mountPath: "/var/opt/jfrog/artifactory"
     enabled: true
@@ -287,8 +295,6 @@ artifactory:
     customBinarystoreXmlSecret:
 
     maxCacheSize: 50000000000
-    cacheProviderDir: cache
-
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:
     ## file-system (default)
@@ -303,8 +309,14 @@ artifactory:
     binarystoreXml: |
       {{- if eq .Values.artifactory.persistence.type "file-system" -}}
       <!-- File system filestore -->
-      <config version="v1">
+      <config version="v2">
           <chain template="file-system"/>
+          {{- if .Values.artifactory.cacheFs.enabled }}
+          <provider id="cache-fs" type="cache-fs">
+              <cacheProviderDir>{{ .Values.artifactory.cacheFs.persistence.mountPath }}</cacheProviderDir>
+              <maxCacheSize>{{ .Values.artifactory.cacheFs.persistence.bytes }}</maxCacheSize>
+          </provider>
+          {{- end }}
       </config>
       {{- end }}
       {{- if eq .Values.artifactory.persistence.type "google-storage" }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
If using the filesystem backend on an NFS mount it is nice to have a second volume mounted for the cache directory since NFS is far too slow for cache. 

This enables an explicit NFS type check in the filestore binarystoreXML and creates a volume for cacheFs


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
