### PR TITLE
[artifactory-ha] Provide resources for initContainers

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.16.4] - Sep 20, 2019
+* Add support for setting `initContainers.resources`
+
 ## [0.16.3] - Sep 11, 2019
 * Updated Artifactory version to 6.12.2
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.16.3
+version: 0.16.4
 appVersion: 6.12.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -88,6 +88,10 @@ helm install --name artifactory-ha \
                --set artifactory.node.resources.limits.memory="4Gi" \
                --set artifactory.node.javaOpts.xms="1g" \
                --set artifactory.node.javaOpts.xmx="4g" \
+               --set initContainers.resources.requests.cpu="10m" \
+               --set initContainers.resources.limits.cpu="250m" \
+               --set initContainers.resources.requests.memory="64Mi" \
+               --set initContainers.resources.limits.memory="128Mi" \
                --set postgresql.resources.requests.cpu="200m" \
                --set postgresql.resources.limits.cpu="1" \
                --set postgresql.resources.requests.memory="500Mi" \
@@ -788,6 +792,10 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.node.javaOpts.other`               | Artifactory member node additional java options  |                     |
 | `artifactory.node.persistence.existingClaim`    | Whether to use existing PVCs for the member nodes | `false`            |
 | `artifactory.terminationGracePeriodSeconds`     | Termination grace period (seconds)               | `30s`               |
+| `initContainers.resources.requests.memory`    | Init containers initial memory request   |                     |
+| `initContainers.resources.requests.cpu`       | Init containers initial cpu request      |                     |
+| `initContainers.resources.limits.memory`      | Init containers memory limit             |                     |
+| `initContainers.resources.limits.cpu`         | Init containers cpu limit                |                     |
 | `ingress.enabled`           | If true, Artifactory Ingress will be created | `false`                                     |
 | `ingress.annotations`       | Artifactory Ingress annotations     | `{}`                                                 |
 | `ingress.labels`       | Artifactory Ingress labels     | `{}`                                                           |

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -48,6 +48,8 @@ spec:
       - name: "create-artifactory-data-dir"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
         - 'sh'
         - '-c'
@@ -62,6 +64,8 @@ spec:
       - name: "delete-db-properties"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
           - 'sh'
           - '-c'
@@ -73,6 +77,8 @@ spec:
       - name: "remove-lost-found"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
         - 'sh'
         - '-c'
@@ -95,6 +101,8 @@ spec:
       {{- end }}
       - name: "wait-for-db"
         image: "{{ .Values.initContainerImage }}"
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
         - 'sh'
         - '-c'

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -51,6 +51,8 @@ spec:
       - name: "create-artifactory-data-dir"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
         - 'sh'
         - '-c'
@@ -65,6 +67,8 @@ spec:
       - name: "delete-db-properties"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
         - 'sh'
         - '-c'
@@ -76,6 +80,8 @@ spec:
       - name: "remove-lost-found"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
         - 'sh'
         - '-c'
@@ -100,6 +106,8 @@ spec:
       - name: "access-bootstrap-creds"
         image: "{{ .Values.initContainerImage }}"
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
           - 'sh'
           - '-c'
@@ -121,6 +129,8 @@ spec:
     {{- end }}
       - name: "wait-for-db"
         image: "{{ .Values.initContainerImage }}"
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         command:
         - 'sh'
         - '-c'

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -770,6 +770,17 @@ artifactory:
       type: ""
       topologyKey: "kubernetes.io/hostname"
 
+# Init containers
+initContainers:
+  resources: {}
+#    requests:
+#      memory: "64Mi"
+#      cpu: "10m"
+#    limits:
+#      memory: "128Mi"
+#      cpu: "250m"
+
+
 # Nginx
 nginx:
   enabled: true


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md


**What this PR does / why we need it**: In some cases, you must specify the continer resources on k8s platforms managed by the client with specific restrictions. Currently, you can define resources for artifactory primary and node containers. But you can't for the init containers.


**Which issue this PR fixes**: fixes #473

@amithins
@danielezer 
@eldada 
@rimusz 

