### PR TITLE
[xray] custom init containers before the predefined init containers

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.1] - Sep 26, 2019
+* Add support for running custom init containers before the predefined init containers using `common.customInitContainersBegin` 
+
 ## [1.1.0] - Sep 3, 2019
 * Update Xray version to 2.9.0
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.9.0
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -229,10 +229,14 @@ kubectl logs -n <NAMESPACE> <POD_NAME> -c <LOG_CONTAINER_NAME>
 ### Custom init containers
 There are cases where a special, unsupported init processes is needed like checking something on the file system or testing something before spinning up the main container.
 
-For this, there is a section for writing a custom init container in the [values.yaml](values.yaml). By default it's commented out
+For this, there is a section for writing custom init containers before and after the predefined init containers in the [values.yaml](values.yaml) . By default it's commented out
 ```yaml
 common:
-  ## Add custom init containers
+  ## Add custom init containers executed before predefined init containers
+  customInitContainersBegin: |
+    ## Init containers template goes here ##
+
+    ## Add custom init containers executed after predefined init containers
   customInitContainers: |
     ## Init containers template goes here ##
 ```
@@ -316,7 +320,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `common.xrayGroupId`                           | Xray Group Id                                | `1035`               |
 | `common.masterKey`  | Xray Master Key Can be generated with `openssl rand -hex 32` | `FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 | `common.masterKeySecretName`  | Name of precreated secret which contains xray masterKey, key for secret must contain `master-key`  | ` ` |
-| `common.customInitContainers`                  | Custom init containers                       | ` `                  |
+| `common.customInitContainersBegin`             | Custom init containers to run before existing init containers                       | ` `                  |
+| `common.customInitContainers`                  | Custom init containers to run after existing init containers                       | ` `                  |
 | `common.xrayConfig`                            | Additional xray yaml configuration to be written to xray_config.yaml file                       | ``                  |
 | `global.mongoUrl`                              | Xray external MongoDB URL                    | ` `                  |
 | `global.postgresqlUrl`                         | Xray external PostgreSQL URL                 | ` `                  |

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -37,6 +37,9 @@ spec:
         runAsUser: {{ .Values.common.xrayUserId }}
         fsGroup: {{ .Values.common.xrayGroupId }}
       initContainers:
+      {{- if .Values.common.customInitContainersBegin }}
+{{ tpl .Values.common.customInitContainersBegin . | indent 6 }}
+      {{- end }}
       - name: init-wait
         image: {{ .Values.initContainerImage | quote }}
         env:

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -37,6 +37,9 @@ spec:
         runAsUser: {{ .Values.common.xrayUserId }}
         fsGroup: {{ .Values.common.xrayGroupId }}
       initContainers:
+      {{- if .Values.common.customInitContainersBegin }}
+{{ tpl .Values.common.customInitContainersBegin . | indent 6 }}
+      {{- end }}
       - name: init-wait
         image: {{ .Values.initContainerImage | quote }}
         env:

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -37,6 +37,9 @@ spec:
         runAsUser: {{ .Values.common.xrayUserId }}
         fsGroup: {{ .Values.common.xrayGroupId }}
       initContainers:
+      {{- if .Values.common.customInitContainersBegin }}
+{{ tpl .Values.common.customInitContainersBegin . | indent 6 }}
+      {{- end }}
       - name: init-wait
         image: {{ .Values.initContainerImage | quote }}
         env:

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -37,6 +37,9 @@ spec:
         runAsUser: {{ .Values.common.xrayUserId }}
         fsGroup: {{ .Values.common.xrayGroupId }}
       initContainers:
+      {{- if .Values.common.customInitContainersBegin }}
+{{ tpl .Values.common.customInitContainersBegin . | indent 6 }}
+      {{- end }}
       - name: init-wait
         image: {{ .Values.initContainerImage | quote }}
         env:

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -254,7 +254,20 @@ common:
     stdOutEnabled: true
     indexAllBuilds: false
 
-  ## Add custom init containers
+  ## Add custom init containers execution before predefined init containers
+  customInitContainersBegin: |
+  #  - name: "custom-setup"
+  #    image: "{{ .Values.initContainerImage }}"
+  #    imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+  #    command:
+  #      - 'sh'
+  #      - '-c'
+  #      - 'touch {{ .Values.common.xrayConfigPath }}/example-custom-setup'
+  #    volumeMounts:
+  #      - mountPath: "{{ .Values.common.xrayConfigPath }}"
+  #        name: data-volume
+
+  ## Add custom init containers execution after predefined init containers
   customInitContainers: |
   #  - name: "custom-setup"
   #    image: "{{ .Values.initContainerImage }}"


### PR DESCRIPTION
…init containers using `common.customInitContainersBegin`

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds the option to define custom init containers to be run before the predefined init containers. This was requested by a customer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

