### PR TITLE
add unneeded resources cleaner

### DIFF
--- a/test/cleaner/install_jamadar.sh
+++ b/test/cleaner/install_jamadar.sh
@@ -1,0 +1,3 @@
+#/bin/bash
+
+helm tiller run -- helm upgrade --install jamadar --namespace jamadar jamadar/ -f override-values.yaml

--- a/test/cleaner/jamadar/Chart.yaml
+++ b/test/cleaner/jamadar/Chart.yaml
@@ -1,0 +1,13 @@
+# Generated from deployments/kubernetes/templates/chart/Chart.yaml.tmpl
+
+apiVersion: v1
+name: jamadar
+description: Jamadar chart that runs on kubernetes
+version: v0.0.15
+keywords:
+  - Jamadar
+  - kubernetes
+home: https://github.com/stakater/Jamadar
+maintainers:
+- name: Stakater
+  email: hello@stakater.com

--- a/test/cleaner/jamadar/templates/_helpers.tpl
+++ b/test/cleaner/jamadar/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | lower -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "labels.selector" -}}
+app: {{ template "name" . }}
+group: {{ .Values.jamadar.labels.group }}
+provider: {{ .Values.jamadar.labels.provider }}
+{{- end -}}
+
+{{- define "labels.stakater" -}}
+{{ template "labels.selector" . }}
+version: {{ .Values.jamadar.labels.version }}
+{{- end -}}
+
+{{- define "labels.chart" -}}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+release: {{ .Release.Name | quote }}
+heritage: {{ .Release.Service | quote }}
+{{- end -}}

--- a/test/cleaner/jamadar/templates/configmap.yaml
+++ b/test/cleaner/jamadar/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+{{ include "labels.stakater" . | indent 4 }}
+{{ include "labels.chart" . | indent 4 }}
+  name: {{ template "name" . }}
+data:
+  config.yaml: |-
+    pollTimeInterval: {{ .Values.jamadar.pollTimeInterval }}
+    age: {{ .Values.jamadar.age }}
+    resources:
+    {{- range .Values.jamadar.resources }}
+      - {{ . }}        
+    {{- end }}
+    actions:
+      {{- range .Values.jamadar.actions }}
+      - name: {{ .name }}
+        params:
+        {{- range $key, $value := .params }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}    
+    restrictedNamespaces:
+    {{- range .Values.jamadar.restrictedNamespaces }}
+      - {{ . }}        
+    {{- end }}

--- a/test/cleaner/jamadar/templates/deployment.yaml
+++ b/test/cleaner/jamadar/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    configmap.fabric8.io/update-on-change: {{ template "name" . }}
+  labels:
+{{ include "labels.stakater" . | indent 4 }}
+{{ include "labels.chart" . | indent 4 }}
+  name: {{ template "name" . }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+{{ include "labels.selector" . | indent 6 }}
+  template:
+    metadata:
+      annotations:
+        configmap.fabric8.io/update-on-change: {{ template "name" . }}
+      labels:
+{{ include "labels.selector" . | indent 8 }}
+    spec:
+      containers:
+      - env:
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_FILE_PATH
+          value: {{ .Values.jamadar.configFilePath }}
+        image: "{{ .Values.jamadar.image.name }}:{{ .Values.jamadar.image.tag }}"
+        imagePullPolicy: {{ .Values.jamadar.image.pullPolicy }}
+        name: {{ template "name" . }}
+        volumeMounts:
+        - mountPath: /configs
+          name: config-volume
+      serviceAccountName: {{ template "name" . }}
+      volumes:
+      - configMap:
+          name: {{ template "name" . }}
+        name: config-volume
+              

--- a/test/cleaner/jamadar/templates/rbac.yaml
+++ b/test/cleaner/jamadar/templates/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+{{ include "labels.stakater" . | indent 4 }}
+{{ include "labels.chart" . | indent 4 }}
+  name: {{ template "name" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels: 
+{{ include "labels.stakater" . | indent 4 }}
+{{ include "labels.chart" . | indent 4 }}
+  name: {{ template "name" . }}-role
+rules:
+  - apiGroups:
+      - ""
+    resources:      
+      - namespaces
+    verbs:
+      - list
+      - get
+      - watch
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels: 
+{{ include "labels.stakater" . | indent 4 }}
+{{ include "labels.chart" . | indent 4 }}
+  name: {{ template "name" . }}-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "name" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/test/cleaner/jamadar/values.yaml
+++ b/test/cleaner/jamadar/values.yaml
@@ -1,0 +1,29 @@
+# Generated from deployments/kubernetes/templates/chart/values.yaml.tmpl
+
+kubernetes:
+  host: https://kubernetes.default
+
+jamadar:
+  labels:
+    provider: stakater
+    group: com.stakater.platform
+    version: v0.0.15
+  image:
+    name: stakater/jamadar
+    tag: "v0.0.15"
+    pullPolicy: IfNotPresent
+  pollTimeInterval: 20m
+  age: 7d
+  resources:
+  - namespaces
+  actions:
+  - name: slack
+    params:
+      token: <token>
+      channel: <channel-name>
+  restrictedNamespaces:
+  - kube-system
+  - default
+  - kube-public
+
+  configFilePath: /configs/config.yaml

--- a/test/cleaner/override-values.yaml
+++ b/test/cleaner/override-values.yaml
@@ -1,0 +1,13 @@
+jamadar:
+  pollTimeInterval: 60m
+  age: 1d
+  resources:
+  - namespaces
+  actions:
+  
+  restrictedNamespaces:
+  - kube-system
+  - default
+  - kube-public
+  - jamadar
+


### PR DESCRIPTION
Jamadar check every 6o minutes and deletes namespace older than 24 hours.
It is needed as `chart-releaser` leaves behind resources running if it was timed out.