### PR TITLE
[artifactory-ha] - Add custom labels in Nginx deployment and Artifactory statefulset's

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,11 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.17.2] - Oct 21, 2019
+* Add support for setting `artifactory.primary.labels`
+* Add support for setting `artifactory.node.labels`
+* Add support for setting `nginx.labels`
+
 ## [0.17.1] - Oct 10, 2019
 * Updated Artifactory version to 6.13.1
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.17.1
+version: 0.17.2
 appVersion: 6.13.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -767,6 +767,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.javaOpts.other`                        | Artifactory additional java options (for all nodes) |              |
 | `artifactory.replicator.enabled`                    | Enable Artifactory Replicator          | `false`                   |
 | `artifactory.replicator.publicUrl`              | Artifactory Replicator Public URL |                                    |
+| `artifactory.primary.labels`                    | Artifactory primary node labels                  | `{}`                |
 | `artifactory.primary.resources.requests.memory` | Artifactory primary node initial memory request  |                     |
 | `artifactory.primary.resources.requests.cpu`    | Artifactory primary node initial cpu request     |                     |
 | `artifactory.primary.resources.limits.memory`   | Artifactory primary node memory limit            |                     |
@@ -780,6 +781,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.primary.javaOpts.jmx.ssl`              | Enable SSL           |  `false` |
 | `artifactory.primary.javaOpts.other`            | Artifactory primary node additional java options |                     |
 | `artifactory.primary.persistence.existingClaim` | Whether to use an existing pvc for the primary node | `false`            |
+| `artifactory.node.labels`                       | Artifactory member node labels                   | `{}`                |
 | `artifactory.node.replicaCount`                 | Artifactory member node replica count            | `2`                 |
 | `artifactory.node.minAvailable`                 | Artifactory member node min available count      | `1`                 |
 | `artifactory.node.resources.requests.memory`    | Artifactory member node initial memory request   |                     |
@@ -817,6 +819,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `nginx.image.repository`    | Container image                   | `docker.bintray.io/jfrog/nginx-artifactory-pro`        |
 | `nginx.image.version`       | Container version                 | `.Chart.AppVersion`                                    |
 | `nginx.image.pullPolicy`    | Container pull policy             | `IfNotPresent`                                         |
+| `nginx.labels`              | Nginx deployment labels           | `{}`                                                   |
 | `nginx.loggers`        | Artifactory loggers (see values.yaml for possible values) | `[]`                           |
 | `nginx.mainConf`        | Content of the Artifactory nginx main nginx.conf config file | `see values.yaml`                           |
 | `nginx.artifactoryConf`        | Content of Artifactory nginx artifactory.conf config file | `see values.yaml`                           |

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
     component: {{ .Values.artifactory.name }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.artifactory.node.labels }}
+{{ toYaml .Values.artifactory.node.labels | indent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "artifactory-ha.node.name" . }}
   replicas: {{ .Values.artifactory.node.replicaCount }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
     component: {{ .Values.artifactory.name }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.artifactory.primary.labels }}
+{{ toYaml .Values.artifactory.primary.labels | indent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "artifactory-ha.primary.name" . }}
   replicas: 1

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: {{ .Values.nginx.name }}
-{{- if .Values.artifactory.primary.labels }}
+{{- if .Values.nginx.labels }}
 {{ toYaml .Values.nginx.labels | indent 4 }}
 {{- end }}
 spec:

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: {{ .Values.nginx.name }}
+{{- if .Values.artifactory.primary.labels }}
+{{ toYaml .Values.nginx.labels | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.nginx.replicaCount }}
   selector:

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -708,6 +708,7 @@ artifactory:
   ## Customising their resources and java parameters is done here.
   primary:
     name: artifactory-ha-primary
+    labels: {}
     persistence:
       ## Set existingClaim to true or false
       ## If true, you must prepare a PVC with the name e.g `volume-myrelease-artifactory-ha-primary-0`
@@ -745,6 +746,7 @@ artifactory:
 
   node:
     name: artifactory-ha-member
+    labels: {}
     persistence:
       ## Set existingClaim to true or false
       ## If true, you must prepare a PVC with the name e.g `volume-myrelease-artifactory-ha-member-0`
@@ -803,6 +805,7 @@ initContainers:
 nginx:
   enabled: true
   name: nginx
+  labels: {}
   replicaCount: 1
   uid: 104
   gid: 107

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,10 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.18.2] - Oct 21, 2019
+* Add support for setting `artifactory.labels`
+* Add support for setting `nginx.labels`
+
 ## [7.18.1] - Oct 10, 2019
 * Updated Artifactory version to 6.13.1
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.18.1
+version: 7.18.2
 appVersion: 6.13.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -569,6 +569,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.image.pullPolicy`         | Container pull policy             | `IfNotPresent`                              |
 | `artifactory.image.repository`    | Container image                   | `docker.bintray.io/jfrog/artifactory-pro`        |
 | `artifactory.image.version`       | Container tag                     |  `.Chart.AppVersion`                             |
+| `artifactory.labels`              | Artifactory labels                | `{}`                                             |
 | `artifactory.loggers`             | Artifactory loggers (see values.yaml for possible values) | `[]`                     |
 | `artifactory.catalinaLoggers`     | Artifactory Tomcat loggers (see values.yaml for possible values) | `[]`              |
 | `artifactory.customInitContainers`| Custom init containers            |                                                  |
@@ -683,6 +684,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `nginx.image.repository`    | Container image                   | `docker.bintray.io/jfrog/nginx-artifactory-pro`        |
 | `nginx.image.version`       | Container tag                     | `.Chart.AppVersion`                                    |
 | `nginx.image.pullPolicy`    | Container pull policy                   | `IfNotPresent`                                   |
+| `nginx.labels`              | Nginx deployment labels           | `{}`                                                   |
 | `nginx.loggers`        | Artifactory loggers (see values.yaml for possible values) | `[]`                           |
 | `nginx.mainConf`        | Content of the Artifactory nginx main nginx.conf config file | `see values.yaml`                           |
 | `nginx.artifactoryConf`        | Content of Artifactory nginx artifactory.conf config file | `see values.yaml`                           |

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
     component: {{ .Values.artifactory.name }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.artifactory.labels }}
+{{ toYaml .Values.artifactory.labels | indent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "artifactory.name" . }}
   replicas: 1

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: {{ .Values.nginx.name }}
+{{- if .Values.nginx.labels }}
+{{ toYaml .Values.nginx.labels | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.nginx.replicaCount }}
   selector:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -99,6 +99,7 @@ artifactory:
     # Note that by default we use appVersion to get image tag
     # version:
     pullPolicy: IfNotPresent
+  labels: {}
 
   # Delete the db.properties file in ARTIFACTORY_HOME/etc/db.properties
   deleteDBPropertiesOnStartup: true
@@ -510,6 +511,7 @@ artifactory:
 nginx:
   enabled: true
   name: nginx
+  labels: {}
   replicaCount: 1
   uid: 104
   gid: 107


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md


**What this PR does / why we need it**:  To have the chance to define custom labels for the nginx deployment and primary & node sateefulset k8s objects

**Which issue this PR fixes**: fixes #505

@amithins
@danielezer 
@eldada 
@rimusz 