### PR TITLE
Added a nodeSelector subkey to postgresql key

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.3] - Nov 6, 2019
+* Add nodeselector support for Postgresql
+
 ## [1.1.2] - Nov 5, 2019
 * Add support for the aws-s3-v3 filestore, which adds support for pod IAM roles
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 1.1.2
+version: 1.1.3
 appVersion: 6.14.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -116,6 +116,7 @@ postgresql:
   #  limits:
   #    memory: "1Gi"
   #    cpu: "500m"
+  nodeSelector: {}
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
 ## you MUST specify custom database details here or Artifactory will NOT start

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.1.3] - Nov 6, 2019
+* Add nodeselector support for Postgresql
+
 ## [8.1.2] - Nov 5, 2019
 * Add support for the aws-s3-v3 filestore, which adds support for pod IAM roles
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.1.2
+version: 8.1.3
 appVersion: 6.14.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -829,6 +829,7 @@ postgresql:
   #  limits:
   #    memory: "1Gi"
   #    cpu: "500m"
+  nodeSelector: {}
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
 ## specify custom database details here or leave empty and Artifactory will use embedded derby


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ x] CHANGELOG.md updated

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds a nodeSelector attribute for Postgresql in the values.yaml file for both the artifactory and artifactory-ha charts. It is possible in a mixed OS node cluster i.e. Windows and Linux, that the Postgresql database would potentially end up being deployed onto a Windows node causing the container not to come online. This change will ensure all of the nodes are deployed to the correct node type:
`helm install --name artifactory-ha jfrog/artifactory-ha --set nodeselector.kubernetes.io/os=linux`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None that I am aware of

**Special notes for your reviewer**:

None
