### PR TITLE
Set explicit 'postgresql.postgresqlPassword=""' to avoid helm v3 error

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.9] - Nov 14, 2019
+* Set explicit `postgresql.postgresqlPassword=""` to avoid helm v3 error
+
 ## [1.1.8] - Nov 12, 2019
 * Updated Artifactory version to 6.14.1
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 1.1.8
+version: 1.1.9
 appVersion: 6.14.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -99,7 +99,7 @@ postgresql:
     repository: bitnami/postgresql
     tag: 9.6.15-debian-9-r91
   postgresqlUsername: artifactory
-  postgresqlPassword:
+  postgresqlPassword: ""
   postgresqlDatabase: artifactory
   postgresqlConfiguration:
     listenAddresses: "'*'"

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.1.9] - Nov 14, 2019
+* Set explicit `postgresql.postgresqlPassword=""` to avoid helm v3 error
+
 ## [8.1.8] - Nov 12, 2019
 * Updated Artifactory version to 6.14.1
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.1.8
+version: 8.1.9
 appVersion: 6.14.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -824,7 +824,7 @@ postgresql:
     repository: bitnami/postgresql
     tag: 9.6.15-debian-9-r91
   postgresqlUsername: artifactory
-  postgresqlPassword:
+  postgresqlPassword: ""
   postgresqlDatabase: artifactory
   postgresqlConfiguration:
     listenAddresses: "'*'"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

**What this PR does / why we need it**:
Set explicit `postgresql.postgresqlPassword=""` to avoid helm v3 error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #543 


