### PR TITLE
Fix creation of double slash in nginx artifactory configuration

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.10] - Nov 17, 2019
+* Fix creation of double slash in nginx artifactory configuration
+
 ## [1.1.9] - Nov 14, 2019
 * Set explicit `postgresql.postgresqlPassword=""` to avoid helm v3 error
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 1.1.9
+version: 1.1.10
 appVersion: 6.14.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -1016,7 +1016,7 @@ nginx:
       if ( $repo != "" ) {
         rewrite ^/(v1|v2)/(.*) /artifactory/api/docker/$repo/$1/$2 break;
       }
-      rewrite ^/(v1|v2)/([^/]+)(.*)$ /artifactory/api/docker/$2/$1/$3;
+      rewrite ^/(v1|v2)/([^/]+)/(.*)$ /artifactory/api/docker/$2/$1/$3;
       rewrite ^/(v1|v2)/ /artifactory/api/docker/$1/;
 
       chunked_transfer_encoding on;

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.1.10] - Nov 17, 2019
+* Fix creation of double slash in nginx artifactory configuration
+
 ## [8.1.9] - Nov 14, 2019
 * Set explicit `postgresql.postgresqlPassword=""` to avoid helm v3 error
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.1.9
+version: 8.1.10
 appVersion: 6.14.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -715,7 +715,7 @@ nginx:
       if ( $repo != "" ) {
         rewrite ^/(v1|v2)/(.*) /artifactory/api/docker/$repo/$1/$2 break;
       }
-      rewrite ^/(v1|v2)/([^/]+)(.*)$ /artifactory/api/docker/$2/$1/$3;
+      rewrite ^/(v1|v2)/([^/]+)/(.*)$ /artifactory/api/docker/$2/$1/$3;
       rewrite ^/(v1|v2)/ /artifactory/api/docker/$1/;
       chunked_transfer_encoding on;
       client_max_body_size 0;


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
When using Docker with repository path, a URL with double slash is created, which fails `docker pull` commands.

