### PR TITLE
Make the Xray probes customisable

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -2,6 +2,9 @@
 All changes to this chart will be documented in this file.
 
 ## [1.2.7] - Nov 21, 2019
+* Make the Xray probes customisable 
+
+## [1.2.7] - Nov 21, 2019
 * Prevent probes failing on 403 (Forbidden) - fixes
 
 ## [1.2.6] - Nov 20, 2019

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [1.2.7] - Nov 21, 2019
+## [1.2.8] - Nov 21, 2019
 * Make the Xray probes customisable 
 
 ## [1.2.7] - Nov 21, 2019

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 1.2.7
+version: 1.2.8
 appVersion: 2.10.7
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -323,13 +323,6 @@ The following table lists the configurable parameters of the xray chart and thei
 | `common.customInitContainersBegin`             | Custom init containers to run before existing init containers                       | ` `                  |
 | `common.customInitContainers`                  | Custom init containers to run after existing init containers                       | ` `                  |
 | `common.xrayConfig`                            | Additional xray yaml configuration to be written to xray_config.yaml file                       | ``                  |
-| `common.livenessProbe.enabled`                 | Xray liveness probe enabled                       | `true`                  |
-| `common.livenessProbe.path`                    | Xray liveness probe path                       | `/debug/pprof`                  |
-| `common.livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                       | `90`                  |
-| `common.livenessProbe.periodSeconds`           | How often to perform the probe                       | `10`                  |
-| `common.livenessProbe.timeoutSeconds`          | When the probe times out                       | `1`                  |
-| `common.livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe to be considered failed after having succeeded                       | `3`           |
-| `common.livenessProbe.successThreshold`        | Minimum consecutive successes for the probe to be considered successful after having failed             | `1`                  |
 | `global.mongoUrl`                              | Xray external MongoDB URL                    | ` `                  |
 | `global.postgresqlUrl`                         | Xray external PostgreSQL URL                 | ` `                  |
 | `global.postgresqlTlsSecret`                   | Xray external PostgreSQL TLS files secret    | ` `                  |
@@ -341,6 +334,20 @@ The following table lists the configurable parameters of the xray chart and thei
 | `analysis.internalPort`                        | Xray Analysis internal port                  | `7000`               |
 | `analysis.externalPort`                        | Xray Analysis external port                  | `7000`               |
 | `analysis.service.type`                        | Xray Analysis service type                   | `ClusterIP`          |
+| `analysis.livenessProbe.enabled`               | Xray Analysis liveness probe enabled                       | `true`                  |
+| `analysis.livenessProbe.path`                  | Xray Analysis liveness probe path                       | `/debug/pprof`                  |
+| `analysis.livenessProbe.initialDelaySeconds`   | Xray Analysis delay before liveness probe is initiated                       | `90`                  |
+| `analysis.livenessProbe.periodSeconds`         | Xray Analysis how often to perform the probe                       | `10`                  |
+| `analysis.livenessProbe.timeoutSeconds`        | Xray Analysis when the probe times out                       | `1`                  |
+| `analysis.livenessProbe.failureThreshold`      | Xray Analysis minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `analysis.livenessProbe.successThreshold`      | Xray Analysis minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
+| `analysis.readinessProbe.enabled`               | Xray Analysis readiness probe enabled                       | `true`                  |
+| `analysis.readinessProbe.path`                  | Xray Analysis readiness probe path                       | `/debug/pprof`                  |
+| `analysis.readinessProbe.initialDelaySeconds`   | Xray Analysis delay before readiness probe is initiated                       | `90`                  |
+| `analysis.readinessProbe.periodSeconds`         | Xray Analysis how often to perform the probe                       | `10`                  |
+| `analysis.readinessProbe.timeoutSeconds`        | Xray Analysis when the probe times out                       | `1`                  |
+| `analysis.readinessProbe.failureThreshold`      | Xray Analysis minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `analysis.readinessProbe.successThreshold`      | Xray Analysis minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
 | `analysis.persistence.size`                    | Xray Analysis storage size limit             | `10Gi`               |
 | `analysis.resources`                           | Xray Analysis resources                      | `{}`                 |
 | `analysis.loggers`                             | Xray Analysis loggers (see values.yaml for possible values)  | ` `  |
@@ -355,6 +362,20 @@ The following table lists the configurable parameters of the xray chart and thei
 | `indexer.internalPort`                         | Xray Indexer internal port                   | `7002`               |
 | `indexer.externalPort`                         | Xray Indexer external port                   | `7002`               |
 | `indexer.service.type`                         | Xray Indexer service type                    | `ClusterIP`          |
+| `indexer.livenessProbe.enabled`               | Xray Indexer liveness probe enabled                       | `true`                  |
+| `indexer.livenessProbe.path`                  | Xray Indexer liveness probe path                       | `/debug/pprof`                  |
+| `indexer.livenessProbe.initialDelaySeconds`   | Xray Indexer delay before liveness probe is initiated                       | `90`                  |
+| `indexer.livenessProbe.periodSeconds`         | Xray Indexer how often to perform the probe                       | `10`                  |
+| `indexer.livenessProbe.timeoutSeconds`        | Xray Indexer when the probe times out                       | `1`                  |
+| `indexer.livenessProbe.failureThreshold`      | Xray Indexer minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `indexer.livenessProbe.successThreshold`      | Xray Indexer minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
+| `indexer.readinessProbe.enabled`               | Xray Indexer readiness probe enabled                       | `true`                  |
+| `indexer.readinessProbe.path`                  | Xray Indexer readiness probe path                       | `/debug/pprof`                  |
+| `indexer.readinessProbe.initialDelaySeconds`   | Xray Indexer delay before readiness probe is initiated                       | `90`                  |
+| `indexer.readinessProbe.periodSeconds`         | Xray Indexer how often to perform the probe                       | `10`                  |
+| `indexer.readinessProbe.timeoutSeconds`        | Xray Indexer when the probe times out                       | `1`                  |
+| `indexer.readinessProbe.failureThreshold`      | Xray Indexer minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `indexer.readinessProbe.successThreshold`      | Xray Indexer minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
 | `indexer.persistence.existingClaim`            | Provide an existing PersistentVolumeClaim    | `nil`                              |
 | `indexer.persistence.storageClass`             | Storage class of backing PVC                 | `nil (uses default storage class annotation)`      |
 | `indexer.persistence.enabled`                  | Xray Indexer persistence volume enabled      | `true`                             |
@@ -373,6 +394,20 @@ The following table lists the configurable parameters of the xray chart and thei
 | `persist.internalPort`                         | Xray Persist internal port                   | `7003`               |
 | `persist.externalPort`                         | Xray Persist external port                   | `7003`               |
 | `persist.service.type`                         | Xray Persist service type                    | `ClusterIP`          |
+| `persist.livenessProbe.enabled`               | Xray Persist liveness probe enabled                       | `true`                  |
+| `persist.livenessProbe.path`                  | Xray Persist liveness probe path                       | `/debug/pprof`                  |
+| `persist.livenessProbe.initialDelaySeconds`   | Xray Persist delay before liveness probe is initiated                       | `90`                  |
+| `persist.livenessProbe.periodSeconds`         | Xray Persist how often to perform the probe                       | `10`                  |
+| `persist.livenessProbe.timeoutSeconds`        | Xray Persist when the probe times out                       | `1`                  |
+| `persist.livenessProbe.failureThreshold`      | Xray Persist minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `persist.livenessProbe.successThreshold`      | Xray Persist minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
+| `persist.readinessProbe.enabled`               | Xray Persist readiness probe enabled                       | `true`                  |
+| `persist.readinessProbe.path`                  | Xray Persist readiness probe path                       | `/debug/pprof`                  |
+| `persist.readinessProbe.initialDelaySeconds`   | Xray Persist delay before readiness probe is initiated                       | `90`                  |
+| `persist.readinessProbe.periodSeconds`         | Xray Persist how often to perform the probe                       | `10`                  |
+| `persist.readinessProbe.timeoutSeconds`        | Xray Persist when the probe times out                       | `1`                  |
+| `persist.readinessProbe.failureThreshold`      | Xray Persist minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `persist.readinessProbe.successThreshold`      | Xray Persist minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
 | `persist.persistence.size`                     | Xray Persist storage size limit              | `10Gi`               |
 | `persist.loggers`                              | Xray Persist loggers (see values.yaml for possible values)  | ` `   |
 | `persist.resources`                            | Xray Persist resources                       | `{}`                 |
@@ -389,6 +424,20 @@ The following table lists the configurable parameters of the xray chart and thei
 | `server.service.name`                          | Xray server service name                     | `xray`               |
 | `server.service.type`                          | Xray server service type                     | `LoadBalancer`       |
 | `server.service.annotations`                   | Xray server service annotations              | `{}`           |
+| `server.livenessProbe.enabled`               | Xray server liveness probe enabled                       | `true`                  |
+| `server.livenessProbe.path`                  | Xray server liveness probe path                       | `/web/`                  |
+| `server.livenessProbe.initialDelaySeconds`   | Xray server delay before liveness probe is initiated                       | `90`                  |
+| `server.livenessProbe.periodSeconds`         | Xray server how often to perform the probe                       | `10`                  |
+| `server.livenessProbe.timeoutSeconds`        | Xray server when the probe times out                       | `1`                  |
+| `server.livenessProbe.failureThreshold`      | Xray server minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `server.livenessProbe.successThreshold`      | Xray server minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
+| `server.readinessProbe.enabled`               | Xray server readiness probe enabled                       | `true`                  |
+| `server.readinessProbe.path`                  | Xray server readiness probe path                       | `/web/`                  |
+| `server.readinessProbe.initialDelaySeconds`   | Xray server delay before readiness probe is initiated                       | `90`                  |
+| `server.readinessProbe.periodSeconds`         | Xray server how often to perform the probe                       | `10`                  |
+| `server.readinessProbe.timeoutSeconds`        | Xray server when the probe times out                       | `1`                  |
+| `server.readinessProbe.failureThreshold`      | Xray server minimum consecutive failures for the probe to be considered failed after having succeeded        | `3`           |
+| `server.readinessProbe.successThreshold`      | Xray server minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
 | `server.persistence.existingClaim`             | Provide an existing PersistentVolumeClaim    | `nil`                              |
 | `server.persistence.storageClass`              | Storage class of backing PVC                 | `nil (uses default storage class annotation)`      |
 | `server.persistence.enabled`                   | Xray server persistence volume enabled       | `true`                             |

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -323,6 +323,13 @@ The following table lists the configurable parameters of the xray chart and thei
 | `common.customInitContainersBegin`             | Custom init containers to run before existing init containers                       | ` `                  |
 | `common.customInitContainers`                  | Custom init containers to run after existing init containers                       | ` `                  |
 | `common.xrayConfig`                            | Additional xray yaml configuration to be written to xray_config.yaml file                       | ``                  |
+| `common.livenessProbe.enabled`                 | Xray liveness probe enabled                       | `true`                  |
+| `common.livenessProbe.path`                    | Xray liveness probe path                       | `/debug/pprof`                  |
+| `common.livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                       | `90`                  |
+| `common.livenessProbe.periodSeconds`           | How often to perform the probe                       | `10`                  |
+| `common.livenessProbe.timeoutSeconds`          | When the probe times out                       | `1`                  |
+| `common.livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe to be considered failed after having succeeded                       | `3`           |
+| `common.livenessProbe.successThreshold`        | Minimum consecutive successes for the probe to be considered successful after having failed             | `1`                  |
 | `global.mongoUrl`                              | Xray external MongoDB URL                    | ` `                  |
 | `global.postgresqlUrl`                         | Xray external PostgreSQL URL                 | ` `                  |
 | `global.postgresqlTlsSecret`                   | Xray external PostgreSQL TLS files secret    | ` `                  |

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.analysis.resources | indent 10 }}
-      {{- if .Values.xray.common.livenessProbe.enabled }}
+      {{- if .Values.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.xray.common.livenessProbe.path }}
+            path: {{ .Values.common.livenessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.xray.common.readinessProbe.enabled }}
+      {{- if .Values.common.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.xray.common.readinessProbe.path }}
+            path: {{ .Values.common.readinessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
       {{- end }}
 
       {{- $image := .Values.logger.image.repository }}

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -166,7 +166,7 @@ spec:
         readinessProbe:
           httpGet:
             path: {{ .Values.common.readinessProbe.path }}
-            port: 8040
+            port: {{ .Values.analysis.internalPort }}
           initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.analysis.resources | indent 10 }}
-      {{- if .Values.common.livenessProbe.enabled }}
+      {{- if .Values.analysis.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.common.livenessProbe.path }}
+            path: {{ .Values.analysis.livenessProbe.path }}
             port: {{ .Values.analysis.internalPort }}
-          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.analysis.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.analysis.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.analysis.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.analysis.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.analysis.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.common.readinessProbe.enabled }}
+      {{- if .Values.analysis.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.common.readinessProbe.path }}
+            path: {{ .Values.analysis.readinessProbe.path }}
             port: {{ .Values.analysis.internalPort }}
-          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.analysis.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.analysis.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.analysis.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.analysis.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.analysis.readinessProbe.successThreshold }}
       {{- end }}
 
       {{- $image := .Values.logger.image.repository }}

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -151,19 +151,29 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.analysis.resources | indent 10 }}
-        readinessProbe:
-          httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.analysis.internalPort }}
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          failureThreshold: 10
+      {{- if .Values.xray.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.analysis.internalPort }}
-          initialDelaySeconds: 90
-          periodSeconds: 10
+            path: {{ .Values.xray.common.livenessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+      {{- end }}
+      {{- if .Values.xray.common.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.xray.common.readinessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+      {{- end }}
+
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.common.xrayConfigPath }}

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -155,7 +155,7 @@ spec:
         livenessProbe:
           httpGet:
             path: {{ .Values.common.livenessProbe.path }}
-            port: 8040
+            port: {{ .Values.analysis.internalPort }}
           initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.indexer.resources | indent 10 }}
-      {{- if .Values.common.livenessProbe.enabled }}
+      {{- if .Values.indexer.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.common.livenessProbe.path }}
+            path: {{ .Values.indexer.livenessProbe.path }}
             port: {{ .Values.indexer.internalPort }}
-          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.indexer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.indexer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.indexer.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.indexer.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.indexer.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.common.readinessProbe.enabled }}
+      {{- if .Values.indexer.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.common.readinessProbe.path }}
+            path: {{ .Values.indexer.readinessProbe.path }}
             port: {{ .Values.indexer.internalPort }}
-          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.indexer.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.indexer.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.indexer.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.indexer.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.indexer.readinessProbe.successThreshold }}
       {{- end }}
 
       {{- $image := .Values.logger.image.repository }}
@@ -189,15 +189,15 @@ spec:
           - name: data-volume
             mountPath: {{ $mountPath }}
       {{- end }}
-    {{- with .Values.analysis.nodeSelector }}
+    {{- with .Values.indexer.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.analysis.affinity }}
+    {{- with .Values.indexer.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.analysis.tolerations }}
+    {{- with .Values.indexer.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -166,7 +166,7 @@ spec:
         readinessProbe:
           httpGet:
             path: {{ .Values.common.readinessProbe.path }}
-            port: 8040
+            port: {{ .Values.indexer.internalPort }}
           initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -155,7 +155,7 @@ spec:
         livenessProbe:
           httpGet:
             path: {{ .Values.common.livenessProbe.path }}
-            port: 8040
+            port: {{ .Values.indexer.internalPort }}
           initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.indexer.resources | indent 10 }}
-      {{- if .Values.xray.common.livenessProbe.enabled }}
+      {{- if .Values.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.xray.common.livenessProbe.path }}
+            path: {{ .Values.common.livenessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.xray.common.readinessProbe.enabled }}
+      {{- if .Values.common.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.xray.common.readinessProbe.path }}
+            path: {{ .Values.common.readinessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
       {{- end }}
 
       {{- $image := .Values.logger.image.repository }}

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -151,19 +151,29 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.indexer.resources | indent 10 }}
-        readinessProbe:
-          httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.indexer.internalPort }}
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          failureThreshold: 10
+      {{- if .Values.xray.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.indexer.internalPort }}
-          initialDelaySeconds: 90
-          periodSeconds: 10
+            path: {{ .Values.xray.common.livenessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+      {{- end }}
+      {{- if .Values.xray.common.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.xray.common.readinessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+      {{- end }}
+
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.common.xrayConfigPath }}

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.persist.resources | indent 10 }}
-      {{- if .Values.common.livenessProbe.enabled }}
+      {{- if .Values.persist.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.common.livenessProbe.path }}
+            path: {{ .Values.persist.livenessProbe.path }}
             port: {{ .Values.persist.internalPort }}
-          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.persist.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.persist.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.persist.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.persist.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.persist.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.common.readinessProbe.enabled }}
+      {{- if .Values.persist.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.common.readinessProbe.path }}
+            path: {{ .Values.persist.readinessProbe.path }}
             port: {{ .Values.persist.internalPort }}
-          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.persist.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.persist.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.persist.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.persist.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.persist.readinessProbe.successThreshold }}
       {{- end }}
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -151,19 +151,28 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.persist.resources | indent 10 }}
-        readinessProbe:
-          httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.persist.internalPort }}
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          failureThreshold: 10
+      {{- if .Values.xray.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /debug/pprof/
-            port: {{ .Values.persist.internalPort }}
-          initialDelaySeconds: 90
-          periodSeconds: 10
+            path: {{ .Values.xray.common.livenessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+      {{- end }}
+      {{- if .Values.xray.common.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.xray.common.readinessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+      {{- end }}
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.common.xrayConfigPath }}

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -166,7 +166,7 @@ spec:
         readinessProbe:
           httpGet:
             path: {{ .Values.common.readinessProbe.path }}
-            port: 8040
+            port: {{ .Values.persist.internalPort }}
           initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -155,7 +155,7 @@ spec:
         livenessProbe:
           httpGet:
             path: {{ .Values.common.livenessProbe.path }}
-            port: 8040
+            port: {{ .Values.persist.internalPort }}
           initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.persist.resources | indent 10 }}
-      {{- if .Values.xray.common.livenessProbe.enabled }}
+      {{- if .Values.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.xray.common.livenessProbe.path }}
+            path: {{ .Values.common.livenessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.xray.common.readinessProbe.enabled }}
+      {{- if .Values.common.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.xray.common.readinessProbe.path }}
+            path: {{ .Values.common.readinessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
       {{- end }}
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -155,7 +155,7 @@ spec:
         livenessProbe:
           httpGet:
             path: {{ .Values.common.livenessProbe.path }}
-            port: 8040
+            port: {{ .Values.server.internalPort }}
           initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.server.resources | indent 10 }}
-      {{- if .Values.common.livenessProbe.enabled }}
+      {{- if .Values.server.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.common.livenessProbe.path }}
+            path: {{ .Values.server.livenessProbe.path }}
             port: {{ .Values.server.internalPort }}
-          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.common.readinessProbe.enabled }}
+      {{- if .Values.server.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.common.readinessProbe.path }}
+            path: {{ .Values.server.readinessProbe.path }}
             port: {{ .Values.server.internalPort }}
-          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
       {{- end }}
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -151,27 +151,27 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.server.resources | indent 10 }}
-      {{- if .Values.xray.common.livenessProbe.enabled }}
+      {{- if .Values.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.xray.common.livenessProbe.path }}
+            path: {{ .Values.common.livenessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.livenessProbe.successThreshold }}
       {{- end }}
-      {{- if .Values.xray.common.readinessProbe.enabled }}
+      {{- if .Values.common.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.xray.common.readinessProbe.path }}
+            path: {{ .Values.common.readinessProbe.path }}
             port: 8040
-          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+          initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.common.readinessProbe.successThreshold }}
       {{- end }}
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -151,19 +151,28 @@ spec:
           allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.server.resources | indent 10 }}
-        readinessProbe:
-          httpGet:
-            path: /web/
-            port: {{ .Values.server.internalPort }}
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          failureThreshold: 10
+      {{- if .Values.xray.common.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /web/
-            port: {{ .Values.server.internalPort }}
-          initialDelaySeconds: 90
-          periodSeconds: 10
+            path: {{ .Values.xray.common.livenessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.livenessProbe.successThreshold }}
+      {{- end }}
+      {{- if .Values.xray.common.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.xray.common.readinessProbe.path }}
+            port: 8040
+          initialDelaySeconds: {{ .Values.xray.common.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.xray.common.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.xray.common.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.xray.common.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.xray.common.readinessProbe.successThreshold }}
+      {{- end }}
       {{- $image := .Values.logger.image.repository }}
       {{- $tag := .Values.logger.image.tag }}
       {{- $mountPath := .Values.common.xrayConfigPath }}

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -166,7 +166,7 @@ spec:
         readinessProbe:
           httpGet:
             path: {{ .Values.common.readinessProbe.path }}
-            port: 8040
+            port: {{ .Values.server.internalPort }}
           initialDelaySeconds: {{ .Values.common.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.common.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.common.readinessProbe.timeoutSeconds }}

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -254,24 +254,6 @@ common:
     stdOutEnabled: true
     indexAllBuilds: false
 
-  livenessProbe:
-    enabled: true
-    path: /debug/pprof
-    initialDelaySeconds: 90
-    periodSeconds: 10
-    timeoutSeconds: 1
-    failureThreshold: 3
-    successThreshold: 1
-
-  readinessProbe:
-    enabled: true
-    path: /debug/pprof
-    initialDelaySeconds: 60
-    periodSeconds: 10
-    timeoutSeconds: 1
-    failureThreshold: 10
-    successThreshold: 1
-
   ## Add custom init containers execution before predefined init containers
   customInitContainersBegin: |
   #  - name: "custom-setup"
@@ -315,6 +297,25 @@ analysis:
   externalPort: 7000
   service:
     type: ClusterIP
+
+  livenessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 10
+    successThreshold: 1
+
   ## Container storage limit
   persistence:
     size: 10Gi
@@ -342,6 +343,24 @@ indexer:
   externalPort: 7002
   service:
     type: ClusterIP
+
+  livenessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 10
+    successThreshold: 1
 
   persistence:
     enabled: true
@@ -387,6 +406,25 @@ persist:
   externalPort: 7003
   service:
     type: ClusterIP
+
+  livenessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 10
+    successThreshold: 1
+
   ## Container storage limit
   persistence:
     size: 10Gi
@@ -419,6 +457,24 @@ server:
     # external-dns.alpha.kubernetes.io/hostname:  example.org
     # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:XXXXXX:certificate/XXXXXX
+
+  livenessProbe:
+    enabled: true
+    path: /web/
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    path: /web/
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 10
+    successThreshold: 1
 
   persistence:
     enabled: true

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -254,6 +254,24 @@ common:
     stdOutEnabled: true
     indexAllBuilds: false
 
+  livenessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    path: /debug/pprof
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 10
+    successThreshold: 1
+
   ## Add custom init containers execution before predefined init containers
   customInitContainersBegin: |
   #  - name: "custom-setup"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Make the Xray probes customisable 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #542 

**Special notes for your reviewer**:
@arielkv this PR will make the probes customisable so that you can change the probe to your needs. For example, before a big upgrade, you can change the `initialDelayPeriosSeconds` param to 1 hour. This should be enough to fix your issue, since we can't really change the probe only on upgrade because not all upgrade are as big as you describe and having such a long initial delay would be problematic. 