### PR TITLE
* Add an option to use a file system cache-fs with the file-system bi…

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.2.4] - Nov 21, 2019
+* Add an option to use a file system cache-fs with the file-system binarystore template 
+
 ## [8.2.3] - Nov 20, 2019
 * Update Artifactory Readme
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.2.3
+version: 8.2.4
 appVersion: 6.15.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -322,7 +322,22 @@ artifactory:
       {{- if eq .Values.artifactory.persistence.type "file-system" -}}
       <!-- File system filestore -->
       <config version="v1">
-          <chain template="file-system"/>
+          <chain>
+            {{- if .Values.artifactory.persistence.fileSystem.cache.enabled }}
+              <provider id="cache-fs" type="cache-fs">
+            {{- end }}
+                  <provider id="file-system" type="file-system"/>
+            {{- if .Values.artifactory.persistence.fileSystem.cache.enabled }}
+              </provider>
+            {{- end }}
+          </chain>
+
+        {{- if .Values.artifactory.persistence.fileSystem.cache.enabled }}
+          <provider id="cache-fs" type="cache-fs">
+              <maxCacheSize>{{ .Values.artifactory.persistence.maxCacheSize }}</maxCacheSize>
+              <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
+          </provider>
+        {{- end }}
       </config>
       {{- end }}
       {{- if eq .Values.artifactory.persistence.type "google-storage" }}
@@ -505,6 +520,12 @@ artifactory:
       dataDir: "/var/opt/jfrog/artifactory"
       backupDir: "/var/opt/jfrog/artifactory-backup"
       capacity: 200Gi
+
+    ## For artifactory.persistence.type file-system
+    fileSystem:
+      cache:
+        enabled: false
+
     ## For artifactory.persistence.type google-storage
     googleStorage:
       endpoint: storage.googleapis.com


### PR DESCRIPTION
…narystore template. This wll address the issue in PR #469

* Add README guide on how to use the copyOnEveryStartup feature with the binarystore.xml and with custom config files

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add the option to use a filesystem cache in cases when using slow storage like NFS/EFS/slow disks

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Addresses the issue brought up in #469 

**Special notes for your reviewer**:

