### PR TITLE
Adds the ability to mount a single custom ca chain into the xray server and artifactory pods

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.3.1] - Dec 10, 2019
+* Added the ability to define a custom CA certificate in the container
+
 ## [8.3.0] - Dec 1, 2019
 * Updated Artifactory version to 6.16.0
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.3.0
+version: 8.3.1
 appVersion: 6.16.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -876,6 +876,8 @@ NOTE: This key is generated only once and cannot be updated once created | `` |
 | `networkpolicy.podselector`      | Contains the YAML that specifies how to match pods. Usually using matchLabels. |                                         |
 | `networkpolicy.ingress`          | YAML snippet containing to & from rules applied to incoming traffic            | `- {}` (open to all inbound traffic)    |
 | `networkpolicy.egress`           | YAML snippet containing to & from rules applied to outgoing traffic            | `- {}` (open to all outbound traffic)   |
+| `customCA.enabled`                             | Enable to add a custom CA cert to xray       | `false`              |
+| `customCA.name`                                | The config map name and the key of the CA Cert (must match)         | `nil`                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -276,6 +276,11 @@ spec:
         - containerPort: {{ .Values.artifactory.javaOpts.jmx.port }}
         {{- end }}
         volumeMounts:
+      {{- if .Values.customCA.enabled }}
+        - name: custom-ca
+          mountPath: "/etc/ssl/certs/custom-ca.crt"
+          subPath: "custom-ca.crt"
+      {{- end}}
       {{- if .Values.artifactory.userPluginSecrets }}
         - name: tmp-plugins
           mountPath: "/tmp/plugins/"
@@ -391,6 +396,11 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+      {{- if .Values.customCA.enabled}}
+      - name: custom-ca
+        configMap:
+          name: {{ .Values.customCA.name }}
+      {{- end }}
       - name: binarystore-xml
         secret:
           {{- if .Values.artifactory.persistence.customBinarystoreXmlSecret }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -11,6 +11,11 @@ installer:
   type:
   platform:
 
+# Custom CA
+customCA:
+  enabled: false
+  name: ''
+
 # For supporting pulling from private registries
 imagePullSecrets:
 

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [1.3.1] - Dec 9, 2019
-* Added the ability to define a custom CA certificate in the OS
+* Added the ability to define a custom CA certificate in the container
 
 ## [1.3.0] - Dec 3, 2019
 * Update Xray version to 2.11.0

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.3.1] - Dec 9, 2019
+* Added the ability to define a custom CA certificate in the OS
+
 ## [1.3.0] - Dec 3, 2019
 * Update Xray version to 2.11.0
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 1.3.0
+version: 1.3.1
 appVersion: 2.11.0
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -448,6 +448,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `server.nodeSelector`                          | Xray server node selector                    | `{}`                 |
 | `server.affinity`                              | Xray server node affinity                    | `{}`                 |
 | `server.tolerations`                           | Xray server node tolerations                 | `[]`                 |
+| `customCA.enabled`                             | Enable to add a custom CA cert to xray       | `false`              |
+| `customCA.name`                                | The config map name and the key of the CA Cert (must match)         | `nil`                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -147,6 +147,11 @@ spec:
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.common.xrayConfigPath }}"
+        {{- if .Values.customCA.enabled }}
+        - name: custom-ca
+          mountPath: "/etc/ssl/certs/custom-ca.crt"
+          subPath: "custom-ca.crt"
+        {{- end}}
         securityContext:
           allowPrivilegeEscalation: false
         resources:
@@ -201,6 +206,11 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+      {{- if .Values.customCA.enabled}}
+      - name: custom-ca
+        configMap:
+          name: {{ .Values.customCA.name }}
+      {{- end }}
       {{- if not .Values.server.persistence.enabled }}
       - name: data-volume
         emptyDir:

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -8,6 +8,11 @@ imagePullPolicy: IfNotPresent
 initContainerImage: "alpine:3.10"
 imagePullSecrets:
 
+# Custom CA
+customCA:
+  enabled: false
+  name: ''
+
 ## Role Based Access
 ## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
 rbac:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

What this PR does / why we need it:
This PR adds the ability to include an custom CA certificate. This is needed for enclaved environments, as well as corporate environments that use their own CA certs.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Special notes for your reviewer:
Tested on our production environment, it works.
