### PR TITLE
Fix support for custom 'artifactory.internalPort'

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.3.5] - Dec 24, 2019
+* Better support for custom `artifactory.internalPort`
+
 ## [1.3.4] - Dec 23, 2019
 * Mark empty map values with `{}`
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 1.3.4
+version: 1.3.5
 appVersion: 6.16.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -740,7 +740,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.service.annotations` | Artifactory service annotations           | `{}`                            |
 | `artifactory.service.pool`   | Artifactory instances to be in the load balancing pool. `members` or `all` | `members`    |
 | `artifactory.externalPort`   | Artifactory service external port                         | `8081`                        |
-| `artifactory.internalPort`   | Artifactory service internal port                         | `8081`                        |
+| `artifactory.internalPort`   | Artifactory service internal port (**DO NOT** use port lower than 1024)   | `8081`        |
 | `artifactory.internalPortReplicator` | Replicator service internal port | `6061`   |
 | `artifactory.externalPortReplicator` | Replicator service external port | `6061`   |
 | `artifactory.extraEnvironmentVariables`          | Extra environment variables to pass to Artifactory. Supports evaluating strings as templates via the [`tpl`](https://helm.sh/docs/charts_tips_and_tricks/#using-the-tpl-function) function. See [documentation](https://www.jfrog.com/confluence/display/RTF/Installing+with+Docker#InstallingwithDocker-SupportedEnvironmentVariables) |   |

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -272,7 +272,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ART_PRIMARY_BASE_URL
-          value: 'http://{{ template "artifactory-ha.primary.name" . }}:8081/artifactory'
+          value: 'http://{{ template "artifactory-ha.primary.name" . }}:{{ .Values.artifactory.internalPort }}/artifactory'
       {{- if eq .Values.artifactory.persistence.type "file-system" }}
         {{- if .Values.artifactory.persistence.fileSystem.existingSharedClaim.enabled }}
         - name: HA_DATA_DIR
@@ -287,6 +287,14 @@ spec:
         - name: HA_BACKUP_DIR
           value: "{{ .Values.artifactory.persistence.nfs.backupDir }}"
       {{- end }}
+        - name: SERVER_XML_ARTIFACTORY_PORT
+          value: "{{ .Values.artifactory.internalPort }}"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HA_CONTEXT_URL
+          value: "http://$(POD_IP):{{ .Values.artifactory.internalPort }}/artifactory"
 {{- with .Values.artifactory.extraEnvironmentVariables }}
 {{ tpl (toYaml .) $ | indent 8 }}
 {{- end }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -326,6 +326,14 @@ spec:
         - name: HA_BACKUP_DIR
           value: "{{ .Values.artifactory.persistence.nfs.backupDir }}"
       {{- end }}
+        - name: SERVER_XML_ARTIFACTORY_PORT
+          value: "{{ .Values.artifactory.internalPort }}"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HA_CONTEXT_URL
+          value: "http://$(POD_IP):{{ .Values.artifactory.internalPort }}/artifactory"
 {{- with .Values.artifactory.extraEnvironmentVariables }}
 {{ tpl (toYaml .) $ | indent 8 }}
 {{- end }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -309,8 +309,6 @@ artifactory:
   ## Extra environment variables that can be used to tune Artifactory to your needs.
   ## Uncomment and set value as needed
   extraEnvironmentVariables:
-  # - name: SERVER_XML_ARTIFACTORY_PORT
-  #   value: "8081"
   # - name: SERVER_XML_ARTIFACTORY_MAX_THREADS
   #   value: "200"
   # - name: SERVER_XML_ACCESS_MAX_THREADS
@@ -331,6 +329,8 @@ artifactory:
   #       name: my-secret-name
   #       key: my-secret-key
 
+  ## IMPORTANT: If overriding artifactory.internalPort:
+  ## DO NOT use port lower than 1024 as Artifactory runs as non-root and cannot bind to ports lower than 1024!
   membershipPort: 10017
   externalPort: 8081
   internalPort: 8081

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.3.4] - Dec 24, 2019
+* Better support for custom `artifactory.internalPort`
+
 ## [8.3.3] - Dec 23, 2019
 * Mark empty map values with `{}`
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.3.3
+version: 8.3.4
 appVersion: 6.16.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -687,8 +687,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.service.type`| Artifactory service type | `ClusterIP`                                                       |
 | `artifactory.service.loadBalancerSourceRanges`| Artifactory service array of IP CIDR ranges to whitelist (only when service type is LoadBalancer) |  |
 | `artifactory.service.annotations` | Artifactory service annotations           | `{}`                            |
-| `artifactory.externalPort` | Artifactory service external port | `8081`                                                  |
-| `artifactory.internalPort` | Artifactory service internal port | `8081`                                                  |
+| `artifactory.externalPort`   | Artifactory service external port                                         | `8081`        |
+| `artifactory.internalPort`   | Artifactory service internal port (**DO NOT** use port lower than 1024)   | `8081`        |
 | `artifactory.internalPortReplicator` | Replicator service internal port | `6061`                                         |
 | `artifactory.externalPortReplicator` | Replicator service external port | `6061`                                         |
 | `artifactory.livenessProbe.enabled`              | Enable liveness probe                     | `true`                    |

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -264,6 +264,8 @@ spec:
         - name: START_LOCAL_REPLICATOR
           value: "true"
         {{- end }}
+        - name: SERVER_XML_ARTIFACTORY_PORT
+          value: "{{ .Values.artifactory.internalPort }}"
 {{- with .Values.artifactory.extraEnvironmentVariables }}
 {{ tpl (toYaml .) $ | indent 8 }}
 {{- end }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -240,8 +240,6 @@ artifactory:
   ## Extra environment variables that can be used to tune Artifactory to your needs.
   ## Uncomment and set value as needed
   extraEnvironmentVariables:
-  # - name: SERVER_XML_ARTIFACTORY_PORT
-  #   value: "8081"
   # - name: SERVER_XML_ARTIFACTORY_MAX_THREADS
   #   value: "200"
   # - name: SERVER_XML_ACCESS_MAX_THREADS
@@ -275,6 +273,8 @@ artifactory:
     loadBalancerSourceRanges: []
     annotations: {}
 
+  ## IMPORTANT: If overriding artifactory.internalPort:
+  ## DO NOT use port lower than 1024 as Artifactory runs as non-root and cannot bind to ports lower than 1024!
   externalPort: 8081
   internalPort: 8081
   internalPortReplicator: 6061


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Improves the support for setting a custom `artifactory.internalPort`.
- Fix a bug in HA setup
- Improve documentation
- Reduce complexity

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #600 


**Special notes for your reviewer**:

