### PR TITLE
Fix HA Node ID

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [1.4.3] - Jan 27, 2020
-* Removed release name from HA Node ID. Removes risk of the HA Node ID exceeding 40 characters which causes nuget issues. See https://www.jfrog.com/jira/browse/RTFACT-18851.
+* Update HA Node ID to use the pods unique ID. Removes risk of the HA Node ID exceeding 40 characters which causes nuget issues. See https://www.jfrog.com/jira/browse/RTFACT-18851.
 
 ## [1.4.2] - Jan 22, 2020
 * Refined pod disruption budgets to separate nginx and Artifactory pods

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.4.3] - Jan 27, 2020
+* Removed release name from HA Node ID. Removes risk of the HA Node ID exceeding 40 characters which causes nuget issues. See https://www.jfrog.com/jira/browse/RTFACT-18851.
+
 ## [1.4.2] - Jan 22, 2020
 * Refined pod disruption budgets to separate nginx and Artifactory pods
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 1.4.2
+version: 1.4.3
 appVersion: 6.17.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -268,7 +268,9 @@ spec:
         - name: HA_MEMBERSHIP_PORT
           value: "{{ .Values.artifactory.membershipPort }}"
         - name: HA_NODE_ID
-          value: "{{ trimPrefix .Release.Name metadata.name }}"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: ART_PRIMARY_BASE_URL
           value: 'http://{{ template "artifactory-ha.primary.name" . }}:{{ .Values.artifactory.internalPort }}/artifactory'
       {{- if eq .Values.artifactory.persistence.type "file-system" }}

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -268,9 +268,7 @@ spec:
         - name: HA_MEMBERSHIP_PORT
           value: "{{ .Values.artifactory.membershipPort }}"
         - name: HA_NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+          value: "{{ trimPrefix .Release.Name metadata.name }}"
         - name: ART_PRIMARY_BASE_URL
           value: 'http://{{ template "artifactory-ha.primary.name" . }}:{{ .Values.artifactory.internalPort }}/artifactory'
       {{- if eq .Values.artifactory.persistence.type "file-system" }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -309,9 +309,7 @@ spec:
         - name: HA_MEMBERSHIP_PORT
           value: "{{ .Values.artifactory.membershipPort }}"
         - name: HA_NODE_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+          value: "{{ trimPrefix .Release.Name metadata.name }}"
       {{- if eq .Values.artifactory.persistence.type "file-system" }}
         {{- if .Values.artifactory.persistence.fileSystem.existingSharedClaim.enabled }}
         - name: HA_DATA_DIR

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -309,7 +309,9 @@ spec:
         - name: HA_MEMBERSHIP_PORT
           value: "{{ .Values.artifactory.membershipPort }}"
         - name: HA_NODE_ID
-          value: "{{ trimPrefix .Release.Name metadata.name }}"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
       {{- if eq .Values.artifactory.persistence.type "file-system" }}
         {{- if .Values.artifactory.persistence.fileSystem.existingSharedClaim.enabled }}
         - name: HA_DATA_DIR


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR prevents the HA node ID exceeding 40 characters when a release name is over 16 characters. Exceeding a 40 character HA node ID results in errors from Nuget acquiring an HA lock. 

This PR fixes this by using the pod UID for the HA node ID which is always 36 characters instead of using the pod name which is variable based on the release name.

**Which issue this PR fixes** *
This doesn't fix the following issue but avoids it:
https://www.jfrog.com/jira/browse/RTFACT-18851

**Special notes for your reviewer**:

