### PR TITLE
Fix broken table in readme

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.5.2] - Mar 3, 2020
+* Fix broken table in readme on Helm Hub (and Kubeapps Hub)
+
 ## [8.5.1] - Mar 2, 2020
 * Fix broken readme on Helm Hub (and Kubeapps Hub)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.5.1
+version: 8.5.2
 appVersion: 6.18.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -819,8 +819,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.livenessProbe.timeoutSeconds`       | When the probe times out                  | 10                        |
 | `artifactory.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1 |
 | `artifactory.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 10 |
-| `artifactory.masterKey`                          | Artifactory masterkey. A 128-Bit key size (hexadecimal encoded) string (32 hex characters). Can be generated with `openssl rand -hex 16`.
-NOTE: This key is generated only once and cannot be updated once created | `` |
+| `artifactory.masterKey`                          | Artifactory masterkey. A 128-Bit key size (hexadecimal encoded) string (32 hex characters). Can be generated with `openssl rand -hex 16`. NOTE: This key is generated only once and cannot be updated once created. |  |
 | `artifactory.masterKeySecretName`                | Artifactory Master Key secret name |                                                                    |
 | `artifactory.accessAdmin.ip`                     | Artifactory access-admin ip to be set upon startup, can use (*) for 0.0.0.0| 127.0.0.1                                    |
 | `artifactory.accessAdmin.password`               | Artifactory access-admin password to be set upon startup|                                               |


### PR DESCRIPTION
Signed-off-by: Simon Alling <alling.simon@gmail.com>

#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

**What this PR does / why we need it**:

It should fix the large table of configuration values, which wasn't fixed by #658 and hence is still illegible starting at `artifactory.masterKey`.

**Which issue this PR fixes**: #657 (hopefully)

**Special notes for your reviewer:**

#658 did not affect [the latest version at Helm Hub (9.0.15)](https://hub.helm.sh/charts/jfrog/artifactory/9.0.15), so I don't think this PR will either. However, I don't know where to find the code for v9.0.15.