### PR TITLE
Add artifactory baseurl in ingress annotations

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [9.0.25] - Mar 15, 2020
+## [9.0.25] - Mar 16, 2020
 * Update Artifactory readme with extra ingress annotations needed for Artifactory to be set as SSO provider
 
 ## [9.0.24] - Mar 16, 2020

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.0.25] - Mar 15, 2020
+* Update Artifactory readme with extra ingress annotations needed for Artifactory to be set as SSO provider
+
 ## [9.0.24] - Mar 16, 2020
 * Add Unsupported message from 6.18 to 7.2.x (migration)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 9.0.24
+version: 9.0.25
 appVersion: 7.2.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -1173,7 +1173,7 @@ If you're using Artifactory as SSO provider (e.g. with xray), you will need to h
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_pass_header   Server;
-        proxy_set_header    X-Artifactory-Override-Base-Url https://<artifactory-domain>/artifactory;
+        proxy_set_header    X-JFrog-Override-Base-Url https://<artifactory-domain>;
 ```
 
 ### Ingress additional rules

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -1166,6 +1166,16 @@ ingress:
       - "myhost.example.com"
 ```
 
+If you're using Artifactory as SSO provider (e.g. with xray), you will need to have the following annotations, and change <artifactory-domain> with your domain:
+```yaml
+..
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_pass_header   Server;
+        proxy_set_header    X-Artifactory-Override-Base-Url https://<artifactory-domain>/artifactory;
+```
+
 ### Ingress additional rules
 
 You have the option to add additional ingress rules to the Artifactory ingress. An example for this use case can be routing the /xray path to Xray.

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -52,7 +52,6 @@ ingress:
   routerPath: /
   artifactoryPath: /artifactory/
   annotations: {}
-  # If you're using Artifactory as SSO provider (e.g. with xray), you will need to uncomment the following annotations, and change <artifactory-domain> with your domain
   # kubernetes.io/ingress.class: nginx
   # nginx.ingress.kubernetes.io/configuration-snippet: |
   #   proxy_pass_header   Server;

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -52,7 +52,11 @@ ingress:
   routerPath: /
   artifactoryPath: /artifactory/
   annotations: {}
+  # If you're using Artifactory as SSO provider (e.g. with xray), you will need to uncomment the following annotations, and change <artifactory-domain> with your domain
   # kubernetes.io/ingress.class: nginx
+  # nginx.ingress.kubernetes.io/configuration-snippet: |
+  #   proxy_pass_header   Server;
+  #   proxy_set_header    X-Artifactory-Override-Base-Url https://<artifactory-domain>/artifactory;
   # kubernetes.io/tls-acme: "true"
   labels: {}
   # traffic-type: external

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -55,7 +55,7 @@ ingress:
   # kubernetes.io/ingress.class: nginx
   # nginx.ingress.kubernetes.io/configuration-snippet: |
   #   proxy_pass_header   Server;
-  #   proxy_set_header    X-Artifactory-Override-Base-Url https://<artifactory-domain>/artifactory;
+  #   proxy_set_header    X-JFrog-Override-Base-Url https://<artifactory-domain>;
   # kubernetes.io/tls-acme: "true"
   labels: {}
   # traffic-type: external


### PR DESCRIPTION
#### PR Checklist

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds `ingress annotations` to set up the base URL of _artifactory_. This is needed when Artifactory is set as the authentication provider, and a client application (e.g. Xray) wants to communicate with it for SSO. The absence of these headers will result in the following response after redirect from Artifactory login:
```json
{ "info": "Failed to exchange token" }
```

More on this issue in [https://jfrog.com/knowledge-base/why-does-my-login-to-xray-ui-fail-with-a-message-error-token-exchange-in-the-browser-after-entering-credentials-during-the-sso-redirect/](https://jfrog.com/knowledge-base/why-does-my-login-to-xray-ui-fail-with-a-message-error-token-exchange-in-the-browser-after-entering-credentials-during-the-sso-redirect/)

