### PR TITLE
artifactory/ha: feat(sa): Fix service account annotation

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.5.1] - Mar 1, 2020
+* Fix service account annotations
+
 ## [1.5.0] - Mar 1, 2020
 * Updated Artifactory version to 6.18.0
 
@@ -14,7 +17,7 @@ All changes to this chart will be documented in this file.
 * Add support for `tpl` in the `postStartCommand`
 
 ## [1.4.7] - Feb 4, 2020
-* Support customisable Nginx kind 
+* Support customisable Nginx kind
 
 ## [1.4.6] - Feb 2, 2020
 * Add a comment stating that it is recommended to use an external PostgreSQL with a static password for production installations
@@ -172,7 +175,7 @@ All changes to this chart will be documented in this file.
 * Updated Artifactory version to 6.12.0
 
 ## [0.15.15] - Aug 18, 2019
-* Fix existingSharedClaim permissions issue and example 
+* Fix existingSharedClaim permissions issue and example
 
 ## [0.15.14] - Aug 14, 2019
 * Updated Artifactory version to 6.11.6
@@ -188,7 +191,7 @@ All changes to this chart will be documented in this file.
 * Improve binarystore config
     1. Convert to a secret
     2. Move config to values.yaml
-    3. Support an external secret 
+    3. Support an external secret
 
 ## [0.15.10] - Aug 5, 2019
 * Don't create the nginx configmaps when nginx.enabled is false
@@ -197,7 +200,7 @@ All changes to this chart will be documented in this file.
 * Fix masterkey/masterKeySecretName not specified warning render logic in NOTES.txt
 
 ## [0.15.8] - Jul 28, 2019
-* Simplify nginx setup and shorten initial wait for probes 
+* Simplify nginx setup and shorten initial wait for probes
 
 ## [0.15.7] - Jul 25, 2019
 * Updated README about how to apply Artifactory licenses
@@ -212,7 +215,7 @@ All changes to this chart will be documented in this file.
 * Add `artifactory.customVolumeMounts` support to member node statefulset template
 
 ## [0.15.3] - Jul 11, 2019
-* Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration 
+* Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration
 
 ## [0.15.2] - Jul 3, 2019
 * Add the option for changing nginx config using values.yaml and remove outdated reverse proxy documentation
@@ -267,7 +270,7 @@ All changes to this chart will be documented in this file.
 * Fix missing logger image tag
 
 ## [0.13.1] - May 15, 2019
-* Support `artifactory.persistence.cacheProviderDir` for on-premise cluster 
+* Support `artifactory.persistence.cacheProviderDir` for on-premise cluster
 
 ## [0.13.0] - May 7, 2019
 * Updated Artifactory version to 6.10.0

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 1.5.0
+version: 1.5.1
 appVersion: 6.18.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-serviceaccount.yaml
+++ b/stable/artifactory-ha/templates/artifactory-serviceaccount.yaml
@@ -2,10 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.serviceAccount.annotations }}
-  annotations:
-{{ tpl (toYaml .) $ | indent 4 }}
-{{- end}}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ template "artifactory-ha.name" . }}
     chart: {{ template "artifactory-ha.chart" . }}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.5.2] - Mar 10, 2020
+* Fix service account annotations
+
 ## [8.5.1] - Mar 2, 2020
 * Fix broken readme on Helm Hub (and Kubeapps Hub)
 
@@ -11,13 +14,13 @@ All changes to this chart will be documented in this file.
 * Add support for SSH authentication to Artifactory
 
 ## [8.4.7] - Feb 11, 2020
-* Change Artifactory service port name to be hard-coded to `http` instead of using `{{ .Release.Name }}` 
+* Change Artifactory service port name to be hard-coded to `http` instead of using `{{ .Release.Name }}`
 
 ## [8.4.6] - Feb 9, 2020
 * Add support for `tpl` in the `postStartCommand`
 
 ## [8.4.5] - Feb 4, 2020
-* Support customisable Nginx kind 
+* Support customisable Nginx kind
 
 ## [8.4.4] - Feb 2, 2020
 * Add a comment stating that it is recommended to use an external PostgreSQL with a static password for production installations
@@ -62,7 +65,7 @@ All changes to this chart will be documented in this file.
 * Add support for PriorityClass
 
 ## [8.2.4] - Nov 21, 2019
-* Add an option to use a file system cache-fs with the file-system binarystore template 
+* Add an option to use a file system cache-fs with the file-system binarystore template
 
 ## [8.2.3] - Nov 20, 2019
 * Update Artifactory Readme
@@ -172,22 +175,22 @@ All changes to this chart will be documented in this file.
 * Improve binarystore config
     1. Convert to a secret
     2. Move config to values.yaml
-    3. Support an external secret 
+    3. Support an external secret
 
 ## [7.16.7] - Jul 29, 2019
-* Don't create the nginx configmaps when nginx.enabled is false 
+* Don't create the nginx configmaps when nginx.enabled is false
 
 ## [7.16.6] - Jul 24, 2019
-* Simplify nginx setup and shorten initial wait for probes 
+* Simplify nginx setup and shorten initial wait for probes
 
 ## [7.16.5] - Jul 22, 2019
-* Change Ingress API to be compatible with recent kubernetes versions 
+* Change Ingress API to be compatible with recent kubernetes versions
 
 ## [7.16.4] - Jul 22, 2019
 * Updated Artifactory version to 6.11.3
 
 ## [7.16.3] - Jul 11, 2019
-* Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration 
+* Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration
 
 ## [7.16.2] - Jul 3, 2019
 * Fix values key in reverse proxy example
@@ -199,7 +202,7 @@ All changes to this chart will be documented in this file.
 * Update Artifactory version to 6.11 and add restart to Artifactory when bootstrap.creds file has been modified
 
 ## [7.15.8] - Jun 27, 2019
-* Add the option for changing nginx config using values.yaml and remove outdated reverse proxy documentation  
+* Add the option for changing nginx config using values.yaml and remove outdated reverse proxy documentation
 
 ## [7.15.6] - Jun 24, 2019
 * Update chart maintainers

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 8.5.1
+version: 8.5.2
 appVersion: 6.18.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-serviceaccount.yaml
+++ b/stable/artifactory/templates/artifactory-serviceaccount.yaml
@@ -2,10 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.serviceAccount.annotations }}
-  annotations:
-{{ tpl (toYaml .) $ | indent 4 }}
-{{- end}}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}


### PR DESCRIPTION
The old implementation of serviceAccount.annotations does't work, is not documented and even with reverse engineering the helm chart I was unable to put a service account annotation in.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

