### PR TITLE
artifactory: Fixed: typo logabck.xml -> logback.xml

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.0.25] - Mar 16, 2020
+* Fix docs typo logabck.xml -> logback.xml
+
 ## [9.0.24] - Mar 16, 2020
 * Add Unsupported message from 6.18 to 7.2.x (migration)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 9.0.24
+version: 9.0.25
 appVersion: 7.2.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -415,7 +415,7 @@ Install the helm chart with the values file you created:
 helm upgrade --install artifactory jfrog/artifactory -f values.yaml
 ```
 
-2. Any custom configuration file you have to configure artifactory, such as `logabck.xml`:
+2. Any custom configuration file you have to configure artifactory, such as `logback.xml`:
 Create a config map with your `logback.xml` configuration.
 
 Create a values file with the following values:


### PR DESCRIPTION
Context suggests it is always supposed to be `logback.xml` and that there is not another file, called `logabck.xml`, which is being referenced.

#### PR Checklist
**What this PR does / why we need it**:
Fixes a typo. Though minor, it could be confusing to someone if they see two different spellings and assume there are two files in play.