### PR TITLE
Update dependency Artifactory chart version to 9.0.26 (Artifactory 7.2.1)

### DIFF
--- a/stable/artifactory-cpp-ce/CHANGELOG.md
+++ b/stable/artifactory-cpp-ce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory CE for C++ Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.12] - Mar 17, 2020
+* Update dependency Artifactory chart version to 9.0.26 (Artifactory 7.2.1)
+
 ## [2.0.11] - Mar 11, 2020
 * Unified charts public release
 

--- a/stable/artifactory-cpp-ce/Chart.yaml
+++ b/stable/artifactory-cpp-ce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-cpp-ce
 home: https://www.jfrog.com/artifactory/
-version: 2.0.11
+version: 2.0.12
 appVersion: 7.2.1
 description: JFrog Artifactory CE for C++
 sources:

--- a/stable/artifactory-cpp-ce/requirements.lock
+++ b/stable/artifactory-cpp-ce/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: artifactory
   repository: https://charts.jfrog.io/
-  version: 9.0.20
-digest: sha256:441ed19c46d8748ad4a61315687a6bc2a9c350d90b04d58c892862447aaae2fc
-generated: 2020-03-08T14:40:03.848735+02:00
+  version: 9.0.26
+digest: sha256:5ede608ecf1b8abeb5b0d87513b146e944dafb764bd72aa652b554cbb1eb9e03
+generated: 2020-03-17T11:28:08.594961+02:00

--- a/stable/artifactory-cpp-ce/requirements.yaml
+++ b/stable/artifactory-cpp-ce/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: artifactory
-    version: 9.0.20
+    version: 9.0.26
     repository: https://charts.jfrog.io/

--- a/stable/artifactory-jcr/CHANGELOG.md
+++ b/stable/artifactory-jcr/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Container Registry Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.12] - Mar 17, 2020
+* Update dependency Artifactory chart version to 9.0.26 (Artifactory 7.2.1)
+
 ## [2.0.11] - Mar 11, 2020
 * Unified charts public release
 

--- a/stable/artifactory-jcr/Chart.yaml
+++ b/stable/artifactory-jcr/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-jcr
 home: https://jfrog.com/container-registry/
-version: 2.0.11
+version: 2.0.12
 appVersion: 7.2.1
 description: JFrog Container Registry
 sources:

--- a/stable/artifactory-jcr/requirements.lock
+++ b/stable/artifactory-jcr/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: artifactory
   repository: https://charts.jfrog.io/
-  version: 9.0.20
-digest: sha256:441ed19c46d8748ad4a61315687a6bc2a9c350d90b04d58c892862447aaae2fc
-generated: 2020-03-08T14:40:13.918133+02:00
+  version: 9.0.26
+digest: sha256:5ede608ecf1b8abeb5b0d87513b146e944dafb764bd72aa652b554cbb1eb9e03
+generated: 2020-03-17T11:28:00.059333+02:00

--- a/stable/artifactory-jcr/requirements.yaml
+++ b/stable/artifactory-jcr/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: artifactory
-    version: 9.0.20
+    version: 9.0.26
     repository: https://charts.jfrog.io/

--- a/stable/artifactory-oss/CHANGELOG.md
+++ b/stable/artifactory-oss/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory OSS Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.12] - Mar 17, 2020
+* Update dependency Artifactory chart version to 9.0.26 (Artifactory 7.2.1)
+
 ## [2.0.11] - Mar 11, 2020
 * Unified charts public release
 

--- a/stable/artifactory-oss/Chart.yaml
+++ b/stable/artifactory-oss/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-oss
 home: https://www.jfrog.com/artifactory/
-version: 2.0.11
+version: 2.0.12
 appVersion: 7.2.1
 description: JFrog Artifactory OSS
 sources:

--- a/stable/artifactory-oss/requirements.lock
+++ b/stable/artifactory-oss/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: artifactory
   repository: https://charts.jfrog.io/
-  version: 9.0.20
-digest: sha256:441ed19c46d8748ad4a61315687a6bc2a9c350d90b04d58c892862447aaae2fc
-generated: 2020-03-08T14:39:49.906269+02:00
+  version: 9.0.26
+digest: sha256:5ede608ecf1b8abeb5b0d87513b146e944dafb764bd72aa652b554cbb1eb9e03
+generated: 2020-03-17T11:27:34.983013+02:00

--- a/stable/artifactory-oss/requirements.yaml
+++ b/stable/artifactory-oss/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: artifactory
-    version: 9.0.20
+    version: 9.0.26
     repository: https://charts.jfrog.io/


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

Update dependency Artifactory chart version to 9.0.26 (Artifactory 7.2.1)
