### PR TITLE
Added ingress annotation to avoid 413 errors.

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.2.11] - Apr 8, 2020
+* Added recommended ingress annotation to avoid 413 errors
+
 ## [2.2.10] - Apr 8, 2020
 * Moved migration scripts under `files` directory
 * Support preStartCommand in migration Init container as `artifactory.migration.preStartCommand`
@@ -97,10 +100,10 @@ All changes to this chart will be documented in this file.
 * Store join key to secret
 
 ## [2.0.19] - Feb 26, 2020
-* Updated Artifactory version to 7.2.1 
+* Updated Artifactory version to 7.2.1
 
 ## [2.0.12] - Feb 07, 2020
-* Remove protection flag `databaseUpgradeReady` which was added to check internal postgres upgrade 
+* Remove protection flag `databaseUpgradeReady` which was added to check internal postgres upgrade
 
 ## [2.0.0] - Feb 07, 2020
 * Updated Artifactory version to 7.0.0
@@ -115,7 +118,7 @@ All changes to this chart will be documented in this file.
 * Add support for `tpl` in the `postStartCommand`
 
 ## [1.4.7] - Feb 4, 2020
-* Support customisable Nginx kind 
+* Support customisable Nginx kind
 
 ## [1.4.6] - Feb 2, 2020
 * Add a comment stating that it is recommended to use an external PostgreSQL with a static password for production installations
@@ -273,7 +276,7 @@ All changes to this chart will be documented in this file.
 * Updated Artifactory version to 6.12.0
 
 ## [0.15.15] - Aug 18, 2019
-* Fix existingSharedClaim permissions issue and example 
+* Fix existingSharedClaim permissions issue and example
 
 ## [0.15.14] - Aug 14, 2019
 * Updated Artifactory version to 6.11.6
@@ -289,7 +292,7 @@ All changes to this chart will be documented in this file.
 * Improve binarystore config
     1. Convert to a secret
     2. Move config to values.yaml
-    3. Support an external secret 
+    3. Support an external secret
 
 ## [0.15.10] - Aug 5, 2019
 * Don't create the nginx configmaps when nginx.enabled is false
@@ -298,7 +301,7 @@ All changes to this chart will be documented in this file.
 * Fix masterkey/masterKeySecretName not specified warning render logic in NOTES.txt
 
 ## [0.15.8] - Jul 28, 2019
-* Simplify nginx setup and shorten initial wait for probes 
+* Simplify nginx setup and shorten initial wait for probes
 
 ## [0.15.7] - Jul 25, 2019
 * Updated README about how to apply Artifactory licenses
@@ -313,7 +316,7 @@ All changes to this chart will be documented in this file.
 * Add `artifactory.customVolumeMounts` support to member node statefulset template
 
 ## [0.15.3] - Jul 11, 2019
-* Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration 
+* Add ingress.hosts to the Nginx server_name directive when ingress is enabled to help with Docker repository sub domain configuration
 
 ## [0.15.2] - Jul 3, 2019
 * Add the option for changing nginx config using values.yaml and remove outdated reverse proxy documentation
@@ -368,7 +371,7 @@ All changes to this chart will be documented in this file.
 * Fix missing logger image tag
 
 ## [0.13.1] - May 15, 2019
-* Support `artifactory.persistence.cacheProviderDir` for on-premise cluster 
+* Support `artifactory.persistence.cacheProviderDir` for on-premise cluster
 
 ## [0.13.0] - May 7, 2019
 * Updated Artifactory version to 6.10.0

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -23,4 +23,4 @@ name: artifactory-ha
 sources:
 - https://bintray.com/jfrog/product/JFrog-Artifactory-Pro/view
 - https://github.com/jfrog/charts
-version: 2.2.10
+version: 2.2.11

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
+  # nginx.ingress.kubernetes.io/proxy-body-size: "0"
   labels: {}
   # traffic-type: external
   # traffic-type: internal

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.2.9] - Apr 8, 2020
+* Added recommended ingress annotation to avoid 413 errors
+
 ## [9.2.8] - Apr 8, 2020
 * Moved migration scripts under `files` directory
 * Support preStartCommand in migration Init container as `artifactory.migration.preStartCommand`

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 9.2.8
+version: 9.2.9
 appVersion: 7.3.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -59,6 +59,7 @@ ingress:
   #   proxy_pass_header   Server;
   #   proxy_set_header    X-JFrog-Override-Base-Url https://<artifactory-domain>;
   # kubernetes.io/tls-acme: "true"
+  # nginx.ingress.kubernetes.io/proxy-body-size: "0"
   labels: {}
   # traffic-type: external
   # traffic-type: internal


### PR DESCRIPTION
#### PR Checklist
- [X] Chart Version bumped
- [X] CHANGELOG.md updated

**What this PR does / why we need it**:
Adds a recommended annotation to values.yaml to avoid 413 errors from the nginx ingress. For us, the ingress was rejecting files as small as 2 MB. 

Additional reading: 
 - https://www.cyberciti.biz/faq/linux-unix-bsd-nginx-413-request-entity-too-large/
 - https://www.jfrog.com/jira/browse/RTFACT-9030
