### PR TITLE
Postgresql use postgresqlExtendedConf

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.1.3] - Mar 24, 2020
+* Use `postgresqlExtendedConf` for setting custom PostgreSQL configuration (instead of `postgresqlConfiguration`)
+
 ## [2.1.2] - Mar 21, 2020
 * Support for SSL offload in Nginx service(LoadBalancer) layer. Introduced `nginx.service.ssloffload` field with boolean type.
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 2.1.2
+version: 2.1.3
 appVersion: 7.3.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -1231,6 +1231,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `postgresql.postgresqlDatabase`   | PostgreSQL database name                   | `artifactory`                           |
 | `postgresql.postgresqlUsername`   | PostgreSQL database user                   | `artifactory`                           |
 | `postgresql.postgresqlPassword`   | PostgreSQL database password               |                                         |
+| `postgresql.postgresqlExtendedConf.listenAddresses` | PostgreSQL listen address            | `"'*'"`                     |
+| `postgresql.postgresqlExtendedConf.maxConnections`  | PostgreSQL max_connections parameter | `1500`                       |
 | `postgresql.persistence.enabled`  | PostgreSQL use persistent storage          | `true`                                  |
 | `postgresql.persistence.size`     | PostgreSQL persistent storage size         | `50Gi`                                  |
 | `postgresql.service.port`         | PostgreSQL database port                   | `5432`                                  |

--- a/stable/artifactory-ha/ci/test-values.yaml
+++ b/stable/artifactory-ha/ci/test-values.yaml
@@ -5,7 +5,7 @@ artifactory:
 
 postgresql:
   postgresqlPassword: "password"
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     maxConnections: "102"
   persistence:
     enabled: true

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -105,7 +105,7 @@ postgresql:
   postgresqlUsername: artifactory
   postgresqlPassword: ""
   postgresqlDatabase: artifactory
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     listenAddresses: "'*'"
     maxConnections: "1500"
   persistence:

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,8 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.1.3] - Mar 24, 2020
+* Use `postgresqlExtendedConf` for setting custom PostgreSQL configuration (instead of `postgresqlConfiguration`)
 
 ## [9.1.2] - Mar 22, 2020
 * Support for SSL offload in Nginx service(LoadBalancer) layer. Introduced `nginx.service.ssloffload` field with boolean type.

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 9.1.2
+version: 9.1.3
 appVersion: 7.3.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -1059,6 +1059,8 @@ The following table lists the configurable parameters of the artifactory chart a
 | `postgresql.postgresqlDatabase`   | PostgreSQL database name                   | `artifactory`                           |
 | `postgresql.postgresqlUsername`   | PostgreSQL database user                   | `artifactory`                           |
 | `postgresql.postgresqlPassword`   | PostgreSQL database password               |                                         |
+| `postgresql.postgresqlExtendedConf.listenAddresses` | PostgreSQL listen address            | `"'*'"`                     |
+| `postgresql.postgresqlExtendedConf.maxConnections`  | PostgreSQL max_connections parameter | `1500`                       |
 | `postgresql.persistence.enabled`  | PostgreSQL use persistent storage          | `true`                                  |
 | `postgresql.persistence.size`     | PostgreSQL persistent storage size         | `50Gi`                                  |
 | `postgresql.service.port`         | PostgreSQL database port                   | `5432`                                  |

--- a/stable/artifactory/ci/test-values.yaml
+++ b/stable/artifactory/ci/test-values.yaml
@@ -4,7 +4,7 @@ artifactory:
 
 postgresql:
   postgresqlPassword: "password"
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     maxConnections: "102"
   persistence:
     enabled: true

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -1065,7 +1065,7 @@ postgresql:
   postgresqlUsername: artifactory
   postgresqlPassword: ""
   postgresqlDatabase: artifactory
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     listenAddresses: "'*'"
     maxConnections: "1500"
   persistence:

--- a/stable/distribution/CHANGELOG.md
+++ b/stable/distribution/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Distribution Chart Changelog
 All changes to this project chart be documented in this file.
 
+## [5.0.18] - Mar 23, 2020
+* Use `postgresqlExtendedConf` for setting custom PostgreSQL configuration (instead of `postgresqlConfiguration`)
+
 ## [5.0.17] - Mar 17, 2020
 * Changed all single quotes to double quotes in values files
 

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: distribution
 home: https://jfrog.com/platform/
 description: A Helm chart for JFrog Distribution
-version: 5.0.17
+version: 5.0.18
 appVersion: 2.2.0
 sources:
 - https://bintray.com/jfrog/product/distribution/view

--- a/stable/distribution/README.md
+++ b/stable/distribution/README.md
@@ -231,7 +231,8 @@ The following table lists the configurable parameters of the distribution chart 
 | `postgresql.postgresqlDatabase`                 | PostgreSQL database name                                               | `distribution`                                                     |
 | `postgresql.postgresqlUsername`                 | PostgreSQL database username                                           | `distribution`                                                     |
 | `postgresql.postgresqlPassword`                 | PostgreSQL database password                                           | ` `                                                                |
-| `postgresql.postgresConfig.maxConnections`      | PostgreSQL max_connections                                             | `1500`                                                             |
+| `postgresql.postgresqlExtendedConf.listenAddresses` | PostgreSQL listen address                                          | `"'*'"`                                                            |
+| `postgresql.postgresqlExtendedConf.maxConnections`  | PostgreSQL max_connections parameter                               | `1500`                                                             |
 | `postgresql.service.port`                       | PostgreSQL service port                                                | `5432`                                                             |
 | `postgresql.persistence.enabled`                | PostgreSQL persistence enabled                                         | `true`                                                             |
 | `postgresql.persistence.size`                   | PostgreSQL persistent disk size                                        | `50Gi`                                                             |

--- a/stable/distribution/values.yaml
+++ b/stable/distribution/values.yaml
@@ -82,7 +82,7 @@ postgresql:
   postgresqlUsername: distribution
   postgresqlPassword: ""
   postgresqlDatabase: distribution
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     listenAddresses: "'*'"
     maxConnections: "1500"
   persistence:

--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.0.21] - Mar 23, 2020
+* Use `postgresqlExtendedConf` for setting custom PostgreSQL configuration (instead of `postgresqlConfiguration`)
+
 ## [3.0.20] - Mar 17, 2020
 * Changed all single quotes to double quotes in values files
 

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 home: https://jfrog.com/mission-control/
-version: 3.0.20
+version: 3.0.21
 appVersion: 4.2.0
 description: A Helm chart for JFrog Mission Control
 sources:

--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -270,6 +270,8 @@ The following table lists the configurable parameters of the mission-control cha
 | `postgresql.persistence.size`                | PostgreSQL persistence volume size              | `50Gi`                                |
 | `postgresql.postgresqlUsernamename`          | PostgreSQL admin username                       | `postgres`                            |
 | `postgresql.postgresqlPassword`              | PostgreSQL admin password                       | ` `                                   |
+| `postgresql.postgresqlExtendedConf.listenAddresses` | PostgreSQL listen address                | `"'*'"`                               |
+| `postgresql.postgresqlExtendedConf.maxConnections`  | PostgreSQL max_connections parameter     | `1500`                                |
 | `postgresql.db.name`                         | PostgreSQL Database name                        | `mission_control`                     |
 | `postgresql.db.sslmode`                      | PostgreSQL Database SSL Mode                    | `false`                               |
 | `postgresql.db.tablespace`                   | PostgreSQL Database Tablespace                  | `pg_default`                          |

--- a/stable/mission-control/values.yaml
+++ b/stable/mission-control/values.yaml
@@ -100,7 +100,7 @@ postgresql:
   postgresqlUsername: postgres
   postgresqlPassword: ""
   postgresqlDatabase: mission_control
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     listenAddresses: "'*'"
     maxConnections: "1500"
   global:

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.0.23] - Mar 23, 2020
+* Use `postgresqlExtendedConf` for setting custom PostgreSQL configuration (instead of `postgresqlConfiguration`)
+
 ## [3.0.22] - Mar 17, 2020
 * Changed all single quotes to double quotes in values files
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 3.0.22
+version: 3.0.23
 appVersion: 3.2.0
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -262,8 +262,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `postgresql.postgresqlUsername`         | PostgreSQL database user                    | `xray`                             |
 | `postgresql.postgresqlPassword`     | PostgreSQL database password                | ` `                                |
 | `postgresql.postgresqlDatabase`     | PostgreSQL database name                    | `xraydb`                           |
-| `postgresql.postgresqlConfiguration.listenAddresses`  | PostgreSQL listen address | `"'*'"`                           |
-| `postgresql.postgresqlConfiguration.maxConnections`  | PostgreSQL max_connections parameter | `500`                           |
+| `postgresql.postgresqlExtendedConf.listenAddresses`  | PostgreSQL listen address | `"'*'"`                           |
+| `postgresql.postgresqlExtendedConf.maxConnections`  | PostgreSQL max_connections parameter | `500`                           |
 | `postgresql.service.port`         | PostgreSQL database port                    | `5432`                             |
 | `postgresql.persistence.enabled`  | PostgreSQL use persistent storage           | `true`                             |
 | `postgresql.persistence.size`     | PostgreSQL persistent storage size          | `50Gi`                             |

--- a/stable/xray/values-large.yaml
+++ b/stable/xray/values-large.yaml
@@ -9,7 +9,7 @@ rabbitmq-ha:
       memory: "2Gi"
       cpu: "2"
 postgresql:
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     maxConnections: "800"
   resources:
     requests:

--- a/stable/xray/values-medium.yaml
+++ b/stable/xray/values-medium.yaml
@@ -10,7 +10,7 @@ rabbitmq-ha:
       cpu: "1"
 
 postgresql:
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     maxConnections: "400"
   resources:
     requests:

--- a/stable/xray/values-small.yaml
+++ b/stable/xray/values-small.yaml
@@ -10,7 +10,7 @@ rabbitmq-ha:
       cpu: "1"
 
 postgresql:
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     maxConnections: "200"
   resources:
     requests:

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -169,7 +169,7 @@ postgresql:
   postgresqlUsername: xray
   postgresqlPassword: ""
   postgresqlDatabase: xraydb
-  postgresqlConfiguration:
+  postgresqlExtendedConf:
     listenAddresses: "'*'"
     maxConnections: "500"
   service:


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Use `postgresqlExtendedConf` for setting custom PostgreSQL configuration (instead of `postgresqlConfiguration`). This will not override core configurations if set, but append to it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #693 

**Special notes for your reviewer**:
See [official PostgreSQL chart](https://github.com/helm/charts/blob/master/stable/postgresql/values.yaml#L177)
