### PR TITLE
Fix volume name used by filebeat container

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.1.4] - Mar 25, 2020
+* Fix volume name used by filebeat container
+
 ## [9.1.3] - Mar 24, 2020
 * Use `postgresqlExtendedConf` for setting custom PostgreSQL configuration (instead of `postgresqlConfiguration`)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 9.1.3
+version: 9.1.4
 appVersion: 7.3.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -449,7 +449,7 @@ spec:
           mountPath: /usr/share/filebeat/filebeat.yml
           readOnly: true
           subPath: filebeat.yml
-        - name: volume
+        - name: artifactory-volume
           mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
         livenessProbe:
 {{ toYaml .Values.filebeat.livenessProbe | indent 10 }}


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

**What this PR does / why we need it**:
Fix volume name used by filebeat container. Was wrongly using `volume` instead of `artifactory-volume`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #718 


**Special notes for your reviewer**:

