### PR TITLE
xray custominitcontainer template fix for ident issue

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [3.1.1] - Apr 14, 2020
+## [3.2.1] - Apr 14, 2020
 * customInitContainer identation template fix
 
 ## [3.1.0] - April 10, 2020

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.1.1] - Apr 14, 2020
+* customInitContainer identation template fix
+
 ## [3.1.0] - April 10, 2020
 * Use dependency charts from `https://charts.bitnami.com/bitnami`
 * Bump postgresql chart version to `8.7.3` in requirements.yaml

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.2.3
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 3.1.1
+version: 3.2.1
 appVersion: 3.2.3
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/templates/xray-statefulset.yaml
+++ b/stable/xray/templates/xray-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
           done;
       {{- end }}
     {{- if .Values.common.customInitContainers }}
-      {{ tpl .Values.common.customInitContainers . }}
+      {{ tpl .Values.common.customInitContainers . | indent 6 }}
     {{- end }}
       containers:
       - name: {{ .Values.router.name }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
If a user specifies uses the customInitContainer tag in our values.yaml including our example it will fail because of indentation issues.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Found issue today submitting for quick fix as xray chart will not install if this option is used for an init container.

**Special notes for your reviewer**:
Tag appeared to be missing the ident call like all other similar tags which is root cause of failure.

