### PR TITLE
artifactory: Change custominitContainer order to run before "migration-artifactory"

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.4.2] - Apr 26, 2020
+* Change order of the customInitContainers to run before the "migration-artifactory" initContainer.
+
 ## [9.4.1] - Apr 16, 2020
 * Custom volumes in migration init container.
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 9.4.1
+version: 9.4.2
 appVersion: 7.4.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -176,6 +176,9 @@ spec:
           done;
       {{- end }}
     {{- end }}
+    {{- if .Values.artifactory.customInitContainers }}
+{{ tpl .Values.artifactory.customInitContainers . | indent 6 }}
+    {{- end }}
       - name: 'migration-artifactory'
         image: '{{ .Values.artifactory.image.repository }}:{{ default .Chart.AppVersion .Values.artifactory.image.version }}'
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
@@ -255,9 +258,6 @@ spec:
       {{- if .Values.artifactory.customVolumeMounts }}
 {{ tpl .Values.artifactory.customVolumeMounts . | indent 8 }}
       {{- end }}
-    {{- if .Values.artifactory.customInitContainers }}
-{{ tpl .Values.artifactory.customInitContainers . | indent 6 }}
-    {{- end }}
       containers:
       - name: {{ .Values.artifactory.name }}
         image: '{{ .Values.artifactory.image.repository }}:{{ default .Chart.AppVersion .Values.artifactory.image.version }}'


### PR DESCRIPTION

#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

**What this PR does / why we need it**:

customInitContainers should be executed before the "migration-artifactory" initContainer to adapt use cases like generating the cacerts file for the run time. 

**Which issue this PR fixes**:

Fixes #831 
