### PR TITLE
[ xray ] Fix notes warning regarding master key

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,5 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
+
+## [3.3.2] - May 20, 2020
+* Skip warning in NOTES if `xray.masterKeySecretName` is set
+
 ## [3.3.1] - May 01, 2020
 * Adding tpl to values to support jfrogUrl
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 3.3.1
+version: 3.3.2
 appVersion: 3.3.0
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/templates/NOTES.txt
+++ b/stable/xray/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Congratulations! JFrog Xray services are deployed!
 
-{{- if and (eq .Values.xray.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") .Values.xray.masterKeySecretName }}
+{{- if and (eq .Values.xray.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") (not .Values.xray.masterKeySecretName) }}
 
 
 ************************************* WARNING *****************************************

--- a/stable/xray/templates/NOTES.txt
+++ b/stable/xray/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Congratulations! JFrog Xray services are deployed!
 
-{{- if eq .Values.xray.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" }}
+{{- if and (eq .Values.xray.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") .Values.xray.masterKeySecretName }}
 
 
 ************************************* WARNING *****************************************


### PR DESCRIPTION
If `.Values.xray.masterKeySecretName` was set, `.Values.xray.masterKey`
is still set to `FFFF...` and causes NOTES to print a warning about it.
This commit fixes that, so the incorrect warning is not printed.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Instead of setting `xray.masterKey`, I'm using `xray.masterKeySecretName`, yet the following warning was printed:

```
************************************* WARNING *****************************************
* Your Xray master key is still set to the provided example:                          *
* xray.masterKey=FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF     *
*                                                                                     *
* You should change this to your own generated key:                                   *
* $ export MASTER_KEY=$(openssl rand -hex 32)                                         *
* $ echo ${MASTER_KEY}                                                                *
*                                                                                     *
* Pass the created master key to helm with '--set xray.masterKey=${MASTER_KEY}'       *
***************************************************************************************
```
