### PR TITLE
[artifactory]- Fixed typo in README regarding migration timeout

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.4.8] - May 24, 2020
+* Fixed typo in README regarding migration timeout
+
 ## [2.4.7] - May 19, 2020
 * Added metadata maxOpenConnections
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 2.4.7
+version: 2.4.8
 appVersion: 7.4.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -1046,8 +1046,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.haBackupDir.path`         | Path to the directory intended for use with NFS eventual configuration for HA   | |
 | `artifactory.haBackupDir.enabled`         | Enable haBackupDir for eventual storage in the HA cluster   | `false` |
 | `artifactory.haBackupDir.path`         | Path to the directory intended for use with NFS eventual configuration for HA   | |
-| `artifactory.migration.timeout`          | Artifactory migration Maximum Time out in seconds| `3600`       |
-| `artifactory.migration.timeout`          | Artifactory migration Maximum Time out in seconds| `3600`       |
+| `artifactory.migration.timeoutSeconds`          | Artifactory migration Maximum Time out in seconds| `3600`       |
 | `artifactory.persistence.mountPath`    | Artifactory persistence volume mount path           | `"/var/opt/jfrog/artifactory"`  |
 | `artifactory.persistence.enabled`      | Artifactory persistence volume enabled              | `true`                          |
 | `artifactory.persistence.accessMode`   | Artifactory persistence volume access mode          | `ReadWriteOnce`                 |

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.4.7] - May 24, 2020
+* Fixed typo in README regarding migration timeout
+
 ## [9.4.6] - May 19, 2020
 * Added metadata maxOpenConnections
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 9.4.6
+version: 9.4.7
 appVersion: 7.4.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -916,7 +916,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.deleteDBPropertiesOnStartup`    | Whether to delete the ARTIFACTORY_HOME/etc/db.properties file on startup. Disabling this will remove the ability for the db.properties to be updated with any DB-related environment variables change (e.g. DB_HOST, DB_URL)  | `true` |
 | `artifactory.database.maxOpenConnections`         | Maximum amount of open connections from Artifactory to the DB   | `80` |
 | `artifactory.copyOnEveryStartup`         | List of files to copy on startup from source (which is absolute) to target (which is relative to ARTIFACTORY_HOME   |  |
-| `artifactory.migration.timeout`          | Artifactory migration Maximum Time out in seounds| `3600`       |
+| `artifactory.migration.timeoutSeconds`          | Artifactory migration Maximum Time out in seounds| `3600`       |
 | `artifactory.persistence.mountPath`      | Artifactory persistence volume mount path        | `"/var/opt/jfrog/artifactory"`       |
 | `artifactory.persistence.enabled`        | Artifactory persistence volume enabled           | `true`                               |
 | `artifactory.persistence.existingClaim`  | Artifactory persistence volume claim name        |                                      |

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -916,7 +916,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `artifactory.deleteDBPropertiesOnStartup`    | Whether to delete the ARTIFACTORY_HOME/etc/db.properties file on startup. Disabling this will remove the ability for the db.properties to be updated with any DB-related environment variables change (e.g. DB_HOST, DB_URL)  | `true` |
 | `artifactory.database.maxOpenConnections`         | Maximum amount of open connections from Artifactory to the DB   | `80` |
 | `artifactory.copyOnEveryStartup`         | List of files to copy on startup from source (which is absolute) to target (which is relative to ARTIFACTORY_HOME   |  |
-| `artifactory.migration.timeoutSeconds`          | Artifactory migration Maximum Time out in seounds| `3600`       |
+| `artifactory.migration.timeoutSeconds`          | Artifactory migration Maximum Timeout in seconds| `3600`       |
 | `artifactory.persistence.mountPath`      | Artifactory persistence volume mount path        | `"/var/opt/jfrog/artifactory"`       |
 | `artifactory.persistence.enabled`        | Artifactory persistence volume enabled           | `true`                               |
 | `artifactory.persistence.existingClaim`  | Artifactory persistence volume claim name        |                                      |


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
According to the statefulset yaml files, we check the value of `artifactory.migration.timeoutSeconds`, while the parameters table in the readme had `artifactory.migration.timeout`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

