### PR TITLE
[xray] 3.4.0 release

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -3,9 +3,9 @@ All changes to this chart will be documented in this file.
 
 ## [3.4.0] - Jun 1, 2020
 * Update Xray to version `3.4.0` - https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.4
-* Bump router version to `1.4.0`
-* Bump postgresql tag version to `9.6.18-debian-10-r7`
-* **Breaking change:** Bump rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine`
+* Update router version to `1.4.0`
+* Update postgresql tag version to `9.6.18-debian-10-r7`
+* **Breaking change:** Update rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine`
 * Added tpl to support external database secrets values
 * Added custom volumes/volumesMounts under `common`
 * Removed custom volumes from each specific service

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -10,7 +10,7 @@ All changes to this chart will be documented in this file.
 * Added tpl to support external database secrets values
 * Added custom volumes/volumesMounts under `common`
 * Removed custom volumes from each specific service
-* Fixes Broken upgrades of charts - use `kubectl delete statefulsets <old_statefulset_distribution_name>` and run helm upgrade
+* Fixes Broken upgrades of charts - use `kubectl delete statefulsets <old_statefulset_xray_name>` and run helm upgrade
 
 ## [3.3.2] - May 20, 2020
 * Skip warning in NOTES if `xray.masterKeySecretName` is set

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -4,9 +4,11 @@ All changes to this chart will be documented in this file.
 ## [3.4.0] - Jun 1, 2020
 * Update Xray to version `3.4.0` - https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.4
 * Bump router version to `1.4.0`
-* Bump postgresql tag version to `9.6.18-debian-10-r7` in values.yaml
-* **Breaking change:** Bump rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine` in values.yaml
+* Bump postgresql tag version to `9.6.18-debian-10-r7`
+* **Breaking change:** Bump rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine`
 * Added tpl to support external database secrets values
+* Added custom volumes/volumesMounts under common
+* Removed custom volumes from each specific service
 
 ## [3.3.2] - May 20, 2020
 * Skip warning in NOTES if `xray.masterKeySecretName` is set

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [3.4.0] - Jun 1, 2020
 * Update Xray to version `3.4.0` - https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.4
+* Added Upgrade Notes in README for 3.x upgrades - https://github.com/jfrog/charts/blob/master/stable/mission-control/README.md#special-upgrade-notes
 * Update router version to `1.4.0`
 * Update postgresql tag version to `9.6.18-debian-10-r7`
 * **Breaking change:** Update rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine`

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,13 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.4.0] - Jun 1, 2020
+* Update Xray to version `3.4.0` - https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.4
+* Bump router version to `1.4.0`
+* Bump postgresql tag version to `9.6.18-debian-10-r7` in values.yaml
+* **Breaking change:** Bump rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine` in values.yaml
+* Added tpl to support external database secrets values
+
 ## [3.3.2] - May 20, 2020
 * Skip warning in NOTES if `xray.masterKeySecretName` is set
 

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -6,7 +6,6 @@ All changes to this chart will be documented in this file.
 * Added Upgrade Notes in README for 3.x upgrades - https://github.com/jfrog/charts/blob/master/stable/mission-control/README.md#special-upgrade-notes
 * Update router version to `1.4.0`
 * Update postgresql tag version to `9.6.18-debian-10-r7`
-* **Breaking change:** Update rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine`
 * Added tpl to support external database secrets values
 * Added custom volumes/volumesMounts under `common`
 * Removed custom volumes from each specific service

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -7,7 +7,7 @@ All changes to this chart will be documented in this file.
 * Bump postgresql tag version to `9.6.18-debian-10-r7`
 * **Breaking change:** Bump rabbitmq/rabbitmq-ha tag versions to `3.8.3-alpine`
 * Added tpl to support external database secrets values
-* Added custom volumes/volumesMounts under common
+* Added custom volumes/volumesMounts under `common`
 * Removed custom volumes from each specific service
 
 ## [3.3.2] - May 20, 2020

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -10,6 +10,7 @@ All changes to this chart will be documented in this file.
 * Added tpl to support external database secrets values
 * Added custom volumes/volumesMounts under `common`
 * Removed custom volumes from each specific service
+* Fixes Broken upgrades of charts - use `kubectl delete statefulsets <old_statefulset_distribution_name>` and run helm upgrade
 
 ## [3.3.2] - May 20, 2020
 * Skip warning in NOTES if `xray.masterKeySecretName` is set

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 3.3.2
-appVersion: 3.3.0
+version: 3.4.0
+appVersion: 3.4.0
 description: Universal component scan for security and license inventory and impact
   analysis
 sources:

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -367,13 +367,10 @@ The following table lists the configurable parameters of the xray chart and thei
 | `global.postgresqlTlsSecret`                   | Xray external PostgreSQL TLS files secret    | ` `                  |
 | `analysis.name`                                | Xray Analysis name                           | `xray-analysis`      |
 | `analysis.image`                               | Xray Analysis container image                | `docker.bintray.io/jfrog/xray-analysis` |
-| `analysis.updateStrategy`                      | Xray Analysis update strategy                | `RollingUpdate`      |
-| `analysis.podManagementPolicy`                 | Xray Analysis pod management policy          | `Parallel`           |
 | `analysis.internalPort`                        | Xray Analysis internal port                  | `7000`               |
 | `analysis.externalPort`                        | Xray Analysis external port                  | `7000`               |
 | `analysis.livenessProbe`                       | Xray Analysis livenessProbe                  | See `values.yaml`    |
 | `analysis.readinessProbe`                      | Xray Analysis readinessProbe                 | See `values.yaml`    |
-| `analysis.persistence.size`                    | Xray Analysis storage size limit             | `10Gi`               |
 | `analysis.resources`                           | Xray Analysis resources                      | `{}`                 |
 | `analysis.preStartCommand`                     | Xray Analysis Custom command to run before startup. Runs AFTER the `common.preStartCommand` |     |
 | `analysis.nodeSelector`                        | Xray Analysis node selector                  | `{}`                 |
@@ -383,19 +380,15 @@ The following table lists the configurable parameters of the xray chart and thei
 | `indexer.name`                                 | Xray Indexer name                            | `xray-indexer`       |
 | `indexer.image`                                | Xray Indexer container image                 | `docker.bintray.io/jfrog/xray-indexer`  |
 | `indexer.annotations`                          | Xray Indexer annotations                     | `{}`                               |
-| `indexer.updateStrategy`                       | Xray Indexer update strategy                 | `RollingUpdate`      |
-| `indexer.podManagementPolicy`                  | Xray Indexer pod management policy           | `Parallel`           |
 | `indexer.internalPort`                         | Xray Indexer internal port                   | `7002`               |
 | `indexer.externalPort`                         | Xray Indexer external port                   | `7002`               |
 | `indexer.livenessProbe`                        | Xray Indexer livenessProbe                   | See `values.yaml`    |
 | `indexer.readinessProbe`                       | Xray Indexer readinessProbe                  | See `values.yaml`    |
-| `indexer.customVolumes`                         | Custom volumes                               |                                                  |
 | `indexer.customVolumeMounts`                    | Custom Server volumeMounts                   |                                                  |
 | `indexer.persistence.existingClaim`            | Provide an existing PersistentVolumeClaim    | `nil`                              |
 | `indexer.persistence.storageClass`             | Storage class of backing PVC                 | `nil (uses default storage class annotation)`      |
 | `indexer.persistence.enabled`                  | Xray Indexer persistence volume enabled      | `false`                             |
 | `indexer.persistence.accessMode`               | Xray Indexer persistence volume access mode  | `ReadWriteOnce`                    |
-| `indexer.persistence.size`                     | Xray Indexer persistence volume size         | `50Gi`                             |
 | `indexer.resources`                            | Xray Indexer resources                       | `{}`                 |
 | `indexer.preStartCommand`                      | Xray Indexer Custom command to run before startup. Runs AFTER the `common.preStartCommand` |     |
 | `indexer.nodeSelector`                         | Xray Indexer node selector                   | `{}`                 |
@@ -404,13 +397,10 @@ The following table lists the configurable parameters of the xray chart and thei
 | `persist.name`                                 | Xray Persist name                            | `xray-persist`       |
 | `persist.image`                                | Xray Persist container image                 | `docker.bintray.io/jfrog/xray-persist`  |
 | `persist.annotations`                          | Xray Persist annotations                     | `{}`                               |
-| `persist.updateStrategy`                       | Xray Persist update strategy                 | `RollingUpdate`      |
-| `persist.podManagementPolicy`                  | Xray Persist pod management policy           | `Parallel`           |
 | `persist.internalPort`                         | Xray Persist internal port                   | `7003`               |
 | `persist.externalPort`                         | Xray Persist external port                   | `7003`               |
 | `persist.livenessProbe`                        | Xray Persist livenessProbe                   | See `values.yaml`    |
 | `persist.readinessProbe`                       | Xray Persist readinessProbe                  | See `values.yaml`    |
-| `persist.persistence.size`                     | Xray Persist storage size limit              | `10Gi`               |
 | `persist.preStartCommand`                      | Xray Persist Custom command to run before startup. Runs AFTER the `common.preStartCommand` |     |
 | `persist.resources`                            | Xray Persist resources                       | `{}`                 |
 | `persist.nodeSelector`                         | Xray Persist node selector                   | `{}`                 |
@@ -419,11 +409,8 @@ The following table lists the configurable parameters of the xray chart and thei
 | `server.name`                                  | Xray server name                             | `xray-server`        |
 | `server.image`                                 | Xray server container image                  | `docker.bintray.io/jfrog/xray-server`   |
 | `server.annotations`                           | Xray server annotations                      | `{}`                               |
-| `server.customVolumes`                         | Custom volumes                               |                                                  |
 | `server.customVolumeMounts`                    | Custom Server volumeMounts                   |                                                  |
 | `server.replicaCount`                          | Xray services replica count                  | `1`                  |
-| `server.updateStrategy`                        | Xray server update strategy                  | `RollingUpdate`      |
-| `server.podManagementPolicy`                   | Xray server pod management policy            | `Parallel`           |
 | `server.internalPort`                          | Xray server internal port                    | `8000`               |
 | `server.externalPort`                          | Xray server external port                    | `80`                 |
 | `server.service.name`                          | Xray server service name                     | `xray`               |

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -63,6 +63,8 @@ helm upgrade --install --set xray.joinKeySecretName=my-secret --namespace xray j
 ### Special Upgrade Notes
 Xray 2.x to 3.x (App Version) is not directly supported.For manual upgrade, Please refer [here](https://github.com/jfrog/charts/blob/master/stable/xray/UPGRADE_NOTES.md). If this is an upgrade over an existing Xray 3.x (App Version), explicitly pass `--set unifiedUpgradeAllowed=true` to upgrade.
 
+Also, While upgrading from Xray 3.x to 3.x charts due to breaking changes, use `kubectl delete statefulsets <old_statefulset_xray_name>` and run helm upgrade
+
 
 ### System Configuration
 

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -294,7 +294,7 @@ The following table lists the configurable parameters of the xray chart and thei
 | `postgresql.enabled`              | Use enclosed PostgreSQL as database         | `true`                             |
 | `postgresql.image.registry`              | PostgreSQL Docker image registry         | `docker.bintray.io`                             |
 | `postgresql.image.repository`              | PostgreSQL Docker image repository         | `bitnami/postgresql`                             |
-| `postgresql.image.tag`              | PostgreSQL Docker image tag         | `9.6.15-debian-9-r91`                             |
+| `postgresql.image.tag`              | PostgreSQL Docker image tag         | `9.6.18-debian-10-r7`                             |
 | `postgresql.postgresqlUsername`         | PostgreSQL database user                    | `xray`                             |
 | `postgresql.postgresqlPassword`     | PostgreSQL database password                | ` `                                |
 | `postgresql.postgresqlDatabase`     | PostgreSQL database name                    | `xraydb`                           |
@@ -344,6 +344,7 @@ The following table lists the configurable parameters of the xray chart and thei
 | `rabbitmq-ha.nodeSelector`                     | RabbitMQ node selector                       | `{}`                 |
 | `rabbitmq-ha.tolerations`                      | RabbitMQ node tolerations                    | `[]`                 |
 | `common.xrayVersion`                           | Xray image tag                               | `.Chart.AppVersion`  |
+| `common.rabbitmq.connectionConfigFromEnvironment`| Use rabbitmq connection config from environment variables | `true`  |
 | `common.preStartCommand`                       | Xray Custom command to run before startup. Runs BEFORE any microservice-specific preStartCommand |     |
 | `common.xrayUserId`                            | Xray User Id                                 | `1035`               |
 | `common.xrayGroupId`                           | Xray Group Id                                | `1035`               |

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -60,6 +60,9 @@ helm upgrade --install --set xray.joinKeySecretName=my-secret --namespace xray j
 ```
 **NOTE:** In either case, make sure to pass the same join key on all future calls to `helm install` and `helm upgrade`! This means always passing `--set xray.joinKey=<YOUR_PREVIOUSLY_RETIREVED_JOIN_KEY>`. In the second, this means always passing `--set xray.joinKeySecretName=my-secret` and ensuring the contents of the secret remain unchanged.
 
+### Special Upgrade Notes
+Xray 2.x to 3.x (App Version) is not directly supported.For manual upgrade, Please refer [here](https://github.com/jfrog/charts/blob/master/stable/xray/UPGRADE_NOTES.md). If this is an upgrade over an existing Xray 3.x (App Version), explicitly pass `--set unifiedUpgradeAllowed=true` to upgrade.
+
 
 ### System Configuration
 
@@ -272,6 +275,7 @@ The following table lists the configurable parameters of the xray chart and thei
 
 |         Parameter            |                    Description                   |           Default                  |
 |------------------------------|--------------------------------------------------|------------------------------------|
+| `unifiedUpgradeAllowed`      | Set this flag to `true` for unifiedupgrades      |                                    |
 | `imagePullSecrets`           | Docker registry pull secret                      |                                    |
 | `imagePullPolicy`            | Container pull policy                            | `IfNotPresent`                     |
 | `initContainerImage`         | Init container image                             | `alpine:3.6`                       |

--- a/stable/xray/templates/xray-statefulset.yaml
+++ b/stable/xray/templates/xray-statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     component: {{ .Values.xray.name }}
 {{- if .Release.IsUpgrade }}
-    unifiedUpgradeAllowed: {{ required "\n\n**************************************\nSTOP! UPGRADE from Xray 2.x currently not supported!\nIf this is an upgrade over an existing Xray 3.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade.\n**************************************\n" .Values.unifiedUpgradeAllowed | quote }}
+    unifiedUpgradeAllowed: {{ required "\n\n**************************************\nSTOP! UPGRADE from Xray 2.x (appVersion) currently not supported!\nIf this is an upgrade over an existing Xray 3.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade.\n**************************************\n" .Values.unifiedUpgradeAllowed | quote }}
 {{- end }}
 spec:
   serviceName: "{{ template "xray.fullname" . }}"

--- a/stable/xray/templates/xray-statefulset.yaml
+++ b/stable/xray/templates/xray-statefulset.yaml
@@ -1,34 +1,32 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "xray-server.fullname" . }}
+  name: {{ template "xray.fullname" . }}
   labels:
     app: {{ template "xray.name" . }}
     chart: {{ template "xray.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: {{ .Values.server.name }}
-    version: {{ default .Chart.AppVersion .Values.common.xrayVersion }}
+    component: {{ .Values.xray.name }}
 {{- if .Release.IsUpgrade }}
     unifiedUpgradeAllowed: {{ required "\n\n**************************************\nSTOP! UPGRADE from Xray 2.x currently not supported!\nIf this is an upgrade over an existing Xray 3.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade.\n**************************************\n" .Values.unifiedUpgradeAllowed | quote }}
 {{- end }}
 spec:
-  serviceName: "{{ template "xray-server.fullname" . }}"
+  serviceName: "{{ template "xray.fullname" . }}"
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
-    type: {{ .Values.server.updateStrategy }}
-  podManagementPolicy: {{ .Values.server.podManagementPolicy }}
+    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "xray.name" . }}
       release: {{ .Release.Name }}
-      component: {{ .Values.server.name }}
+      component: {{ .Values.xray.name }}
   template:
     metadata:
       labels:
         app: {{ template "xray.name" . }}
         release: {{ .Release.Name }}
-        component: {{ .Values.server.name }}
+        component: {{ .Values.xray.name }}
       annotations:
         checksum/systemyaml: {{ include (print $.Template.BasePath "/xray-system-yaml.yaml") . | sha256sum }}
         {{- with .Values.analysis.annotations }}
@@ -162,8 +160,8 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.user }}
-              name: {{ .Values.database.secrets.user.name }}
-              key: {{ .Values.database.secrets.user.key }}
+              name: {{ tpl .Values.database.secrets.user.name . }}
+              key: {{ tpl .Values.database.secrets.user.key . }}
         {{- else if .Values.database.user }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-user
@@ -189,13 +187,14 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.url }}
-              name: {{ .Values.database.secrets.url.name }}
-              key: {{ .Values.database.secrets.url.key }}
+              name: {{ tpl .Values.database.secrets.url.name . }}
+              key: {{ tpl .Values.database.secrets.url.key . }}
         {{- else if .Values.database.url }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-url
         {{- end }}
       {{- end }}
+      {{- if .Values.common.rabbitmq.connectionConfigFromEnvironment }}
         - name: JF_SHARED_RABBITMQ_USERNAME
           value: {{ include "rabbitmq.user" .}}
         - name: JF_SHARED_RABBITMQ_URL
@@ -205,6 +204,7 @@ spec:
             secretKeyRef:
               name: {{ include "rabbitmq.passwordSecretName" .}}
               key: rabbitmq-password
+      {{- end }}
         ports:
         - containerPort: {{ .Values.server.internalPort }}
         volumeMounts:
@@ -247,8 +247,8 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.user }}
-              name: {{ .Values.database.secrets.user.name }}
-              key: {{ .Values.database.secrets.user.key }}
+              name: {{ tpl .Values.database.secrets.user.name . }}
+              key: {{ tpl .Values.database.secrets.user.key . }}
         {{- else if .Values.database.user }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-user
@@ -274,13 +274,14 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.url }}
-              name: {{ .Values.database.secrets.url.name }}
-              key: {{ .Values.database.secrets.url.key }}
+              name: {{ tpl .Values.database.secrets.url.name . }}
+              key: {{ tpl .Values.database.secrets.url.key . }}
         {{- else if .Values.database.url }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-url
         {{- end }}
       {{- end }}
+      {{- if .Values.common.rabbitmq.connectionConfigFromEnvironment }}
         - name: JF_SHARED_RABBITMQ_USERNAME
           value: {{ include "rabbitmq.user" .}}
         - name: JF_SHARED_RABBITMQ_URL
@@ -290,6 +291,7 @@ spec:
             secretKeyRef:
               name: {{ include "rabbitmq.passwordSecretName" .}}
               key: rabbitmq-password
+      {{- end }}
         - name: XRAY_HA_NODE_ID
           valueFrom:
             fieldRef:
@@ -336,8 +338,8 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.user }}
-              name: {{ .Values.database.secrets.user.name }}
-              key: {{ .Values.database.secrets.user.key }}
+              name: {{ tpl .Values.database.secrets.user.name . }}
+              key: {{ tpl .Values.database.secrets.user.key . }}
         {{- else if .Values.database.user }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-user
@@ -363,13 +365,14 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.url }}
-              name: {{ .Values.database.secrets.url.name }}
-              key: {{ .Values.database.secrets.url.key }}
+              name: {{ tpl .Values.database.secrets.url.name . }}
+              key: {{ tpl .Values.database.secrets.url.key . }}
         {{- else if .Values.database.url }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-url
         {{- end }}
       {{- end }}
+      {{- if .Values.common.rabbitmq.connectionConfigFromEnvironment }}
         - name: JF_SHARED_RABBITMQ_USERNAME
           value: {{ include "rabbitmq.user" .}}
         - name: JF_SHARED_RABBITMQ_URL
@@ -379,6 +382,7 @@ spec:
             secretKeyRef:
               name: {{ include "rabbitmq.passwordSecretName" .}}
               key: rabbitmq-password
+      {{- end }}
         - name: XRAY_HA_NODE_ID
           valueFrom:
             fieldRef:
@@ -425,8 +429,8 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.user }}
-              name: {{ .Values.database.secrets.user.name }}
-              key: {{ .Values.database.secrets.user.key }}
+              name: {{ tpl .Values.database.secrets.user.name . }}
+              key: {{ tpl .Values.database.secrets.user.key . }}
         {{- else if .Values.database.user }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-user
@@ -452,13 +456,14 @@ spec:
           valueFrom:
             secretKeyRef:
         {{- if .Values.database.secrets.url }}
-              name: {{ .Values.database.secrets.url.name }}
-              key: {{ .Values.database.secrets.url.key }}
+              name: {{ tpl .Values.database.secrets.url.name . }}
+              key: {{ tpl .Values.database.secrets.url.key . }}
         {{- else if .Values.database.url }}
               name: {{ template "xray.fullname" . }}-database-creds
               key: db-url
         {{- end }}
       {{- end }}
+      {{- if .Values.common.rabbitmq.connectionConfigFromEnvironment }}
         - name: JF_SHARED_RABBITMQ_USERNAME
           value: {{ include "rabbitmq.user" .}}
         - name: JF_SHARED_RABBITMQ_URL
@@ -468,6 +473,7 @@ spec:
             secretKeyRef:
               name: {{ include "rabbitmq.passwordSecretName" .}}
               key: rabbitmq-password
+      {{- end }}
         - name: XRAY_K8S_ENV
           value: "true"
         ports:

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -4,13 +4,14 @@
 # Access the values with {{ .Values.key.subkey }}
 
 # General
-initContainerImage: "alpine:3.10"
+initContainerImage: "alpine:3.11"
 imagePullPolicy: IfNotPresent
 imagePullSecrets:
 
 replicaCount: 1
 
 xray:
+  name: xray
   persistence:
     mountPath: /var/opt/jfrog/xray
 
@@ -151,7 +152,7 @@ postgresql:
   image:
     registry: docker.bintray.io
     repository: bitnami/postgresql
-    tag: 9.6.17-debian-10-r72
+    tag: 9.6.18-debian-10-r7
   postgresqlUsername: xray
   postgresqlPassword: ""
   postgresqlDatabase: xraydb
@@ -185,13 +186,13 @@ database:
   ## these values
   secrets: {}
   #  user:
-  #    name: "database-creds"
+  #    name: "xray-database-creds"
   #    key: "db-user"
   #  password:
-  #    name: "database-creds"
+  #    name: "xray-database-creds"
   #    key: "db-password"
   #  url:
-  #    name: "database-creds"
+  #    name: "xray-database-creds"
   #    key: "db-url"
 
 # RabbitMQ HA
@@ -202,7 +203,7 @@ rabbitmq-ha:
   enabled: true
   replicaCount: 1
   image:
-    tag: 3.7.21-alpine
+    tag: 3.8.3-alpine
   rabbitmqUsername: guest
   rabbitmqPassword: ""
   ## Alternatively, you can use a pre-existing secret with a key called rabbitmq-password by specifying existingSecret
@@ -250,7 +251,7 @@ rabbitmq:
   replicas: 1
   rbacEnabled: true
   image:
-    tag: 3.7.19
+    tag: 3.8.3-alpine
   rabbitmq:
     username: guest
     password: ""
@@ -279,6 +280,11 @@ common:
     stdOutEnabled: true
     indexAllBuilds: false
     support-router: true
+
+  # Use rabbitmq connection config from environment variables.
+  # If false, than connection details should be set directly in system.yaml (systemYaml section).
+  rabbitmq:
+    connectionConfigFromEnvironment: true
 
   ## Custom command to run before Xray startup. Runs BEFORE any microservice-specific preStartCommand
   preStartCommand:
@@ -339,8 +345,6 @@ analysis:
   image:
     repository: docker.bintray.io/jfrog/xray-analysis
     # version:
-  updateStrategy: RollingUpdate
-  podManagementPolicy: Parallel
   internalPort: 7000
   externalPort: 7000
   annotations: {}
@@ -390,8 +394,6 @@ indexer:
   image:
     repository: docker.bintray.io/jfrog/xray-indexer
     # version:
-  updateStrategy: RollingUpdate
-  podManagementPolicy: Parallel
   internalPort: 7002
   externalPort: 7002
   annotations: {}
@@ -449,8 +451,6 @@ persist:
   image:
     repository: docker.bintray.io/jfrog/xray-persist
     # version:
-  updateStrategy: RollingUpdate
-  podManagementPolicy: Parallel
   internalPort: 7003
   externalPort: 7003
   annotations: {}
@@ -500,9 +500,6 @@ server:
   image:
     repository: docker.bintray.io/jfrog/xray-server
     # version:
-  updateStrategy: RollingUpdate
-  podManagementPolicy: Parallel
-  replicaCount: 1
   internalPort: 8000
   externalPort: 80
   annotations: {}
@@ -563,7 +560,7 @@ router:
   name: router
   image:
     repository: docker.bintray.io/jfrog/router
-    version: 1.3.0
+    version: 1.4.0
     imagePullPolicy: IfNotPresent
   internalPort: 8082
   externalPort: 8082

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -289,6 +289,18 @@ common:
   ## Custom command to run before Xray startup. Runs BEFORE any microservice-specific preStartCommand
   preStartCommand:
 
+  ## Add custom volumes
+  customVolumes: |
+  #  - name: custom-script
+  #    configMap:
+  #      name: custom-script
+
+  ## Add custom volumesMounts
+  customVolumeMounts: |
+  #  - name: custom-script
+  #    mountPath: "/scripts/script.sh"
+  #    subPath: script.sh
+
   ## Add custom init containers execution before predefined init containers
   customInitContainersBegin: |
   #  - name: "custom-setup"
@@ -349,6 +361,12 @@ analysis:
   externalPort: 7000
   annotations: {}
 
+  ## Add custom volumesMounts
+  customVolumeMounts: |
+  #  - name: custom-script
+  #    mountPath: "/scripts/script.sh"
+  #    subPath: script.sh
+
   livenessProbe:
     enabled: true
     config: |
@@ -397,12 +415,6 @@ indexer:
   internalPort: 7002
   externalPort: 7002
   annotations: {}
-
-  ## Add custom volumes
-  customVolumes: |
-  #  - name: custom-script
-  #    configMap:
-  #      name: custom-script
 
   ## Add custom volumesMounts
   customVolumeMounts: |
@@ -455,6 +467,12 @@ persist:
   externalPort: 7003
   annotations: {}
 
+  ## Add custom volumesMounts
+  customVolumeMounts: |
+  #  - name: custom-script
+  #    mountPath: "/scripts/script.sh"
+  #    subPath: script.sh
+
   livenessProbe:
     enabled: true
     config: |
@@ -503,12 +521,6 @@ server:
   internalPort: 8000
   externalPort: 80
   annotations: {}
-
-  ## Add custom volumes
-  customVolumes: |
-  #  - name: custom-script
-  #    configMap:
-  #      name: custom-script
 
   ## Add custom volumesMounts
   customVolumeMounts: |

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -203,7 +203,7 @@ rabbitmq-ha:
   enabled: true
   replicaCount: 1
   image:
-    tag: 3.8.3-alpine
+    tag: 3.7.21-alpine
   rabbitmqUsername: guest
   rabbitmqPassword: ""
   ## Alternatively, you can use a pre-existing secret with a key called rabbitmq-password by specifying existingSecret
@@ -251,7 +251,7 @@ rabbitmq:
   replicas: 1
   rbacEnabled: true
   image:
-    tag: 3.8.3-alpine
+    tag: 3.7.19
   rabbitmq:
     username: guest
     password: ""


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
* Update Xray to version `3.4.0` - https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.4
* Added Upgrade Notes in README for 3.x upgrades - https://github.com/jfrog/charts/blob/master/stable/mission-control/README.md#special-upgrade-notes
* Bump router version to `1.4.0`
* Bump postgresql tag version to `9.6.18-debian-10-r7`
* Added tpl to support external database secrets values
* Added custom volumes/volumesMounts under `common`
* Removed custom volumes from each specific service