### PR TITLE
[artifactory-ha]Service annotations for members and primary.

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.5.2] - Jun 5, 2020
+* Applies service annotations to primary service (Previously only applied to members service)
+
 ## [2.5.1] - Jun 5, 2020
 * Fixes broken PDB issue upgrading from 6.x to 7.x
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 2.5.1
+version: 2.5.2
 appVersion: 7.5.5
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-service.yaml
+++ b/stable/artifactory-ha/templates/artifactory-service.yaml
@@ -65,6 +65,10 @@ metadata:
     component: {{ .Values.artifactory.name }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.artifactory.service.annotations }}
+  annotations:
+{{ toYaml .Values.artifactory.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.artifactory.service.type }}
   {{- if and (eq .Values.artifactory.service.type "ClusterIP") .Values.artifactory.service.clusterIP }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
When using the loadbalancer type for artifactory.services, the non-primary members service is the only service that has annotations applied to it. We utilize the annotations to specify an internal AWS LB. This allows us to use our inter-datacenter load balancers to route traffic over DirectConnect to our EKS Artifactory as well as our On-Prem Artifactory instances.

We utilize Istio as public ingress which is why the nginx and kubernetes ingress is disabled(sidecar injection does not seem to play nice with nginx). 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
I ran make lint successfully prior to opening the PR and deployed to a test EKS cluster with the "service.beta.kubernetes.io/aws-load-balancer-internal=true" annotation set on artifactory.services.annotations and confirmed both primary and member services were provisioned with and internal AWS ELB as expected.
