### PR TITLE
Bump helm version

### DIFF
--- a/pipelines/ci-rt.yml
+++ b/pipelines/ci-rt.yml
@@ -3,7 +3,7 @@ pipelines:
     configuration:
       environmentVariables:
         readOnly:
-          HELM_VERSION: 3.2.3
+          HELM_VERSION: 3.2.4
     steps:
       - name: install_rt
         type: Bash

--- a/pipelines/pr.yml
+++ b/pipelines/pr.yml
@@ -10,7 +10,7 @@ pipelines:
           TEST_IMAGE_TAG: v3.4.1
           CHARTS_REPO: https://github.com/jfrog/charts
           KUBEVAL_VERSION: 0.15.0
-          HELM_VERSION: v2.16.8
+          HELM_VERSION: v2.16.9
           CHART_TESTING_ARGS: ""
           GCLOUD_GKE_CLUSTER: ${int_charts_testing_cluster_cluster}
           GCLOUD_SERVICE_KEY_CHARTS_CI: ${int_charts_testing_cluster_gcp_service_key}


### PR DESCRIPTION
**What this PR does / why we need it**:
Helm v2.16.9 is a companion release to Helm 3.2.4, which had a vulnerability in the handling of plugins. Helm 2 does not have a known security vulnerability. However, we determined that Helm 2 should fail with an error message instead of fixing malformed paths when it detected them. We believe this proactive step will decrease the likelihood of a future vulnerability.


