### PR TITLE
[xray] postgresql 10.x update

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -4,7 +4,6 @@ All changes to this chart will be documented in this file.
 ## [4.0.0] - Jun 26, 2020
 * Update postgresql tag version to `10.13.0-debian-10-r38`
 * Update alpine tag version to `3.12`
-* Update rabbitmq-ha tag version to 3.8.5-alpine
 * Update rabbitmq tag version to 3.8.5-debian-10-r14
 * Update RabbitMQ chart to v7.3.3
 * Update RabbitMQ-HA chart to v1.46.4

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -6,6 +6,8 @@ All changes to this chart will be documented in this file.
 * Update alpine tag version to `3.12`
 * Update rabbitmq-ha tag version to 3.8.5-alpine
 * Update rabbitmq tag version to 3.8.5-debian-10-r14
+* Update RabbitMQ chart to v7.3.3
+* Update RabbitMQ-HA chart to v1.46.4
 * **IMPORTANT**
 * If this is a new deployment or you already use an external database (`postgresql.enabled=false`), these changes **do not affect you**!
 * If this is an upgrade and you are using the default PostgreSQL (`postgresql.enabled=true`), you need to pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -4,6 +4,8 @@ All changes to this chart will be documented in this file.
 ## [4.0.0] - Jun 26, 2020
 * Update postgresql tag version to `10.13.0-debian-10-r38`
 * Update alpine tag version to `3.12`
+* Update rabbitmq-ha tag version to 3.8.5-alpine
+* Update rabbitmq tag version to 3.8.5-debian-10-r14
 * **IMPORTANT**
 * If this is a new deployment or you already use an external database (`postgresql.enabled=false`), these changes **do not affect you**!
 * If this is an upgrade and you are using the default PostgreSQL (`postgresql.enabled=true`), you need to pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,13 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.0] - Jun 26, 2020
+* Update postgresql tag version to `10.13.0-debian-10-r38`
+* Update alpine tag version to `3.12`
+* **IMPORTANT**
+* If this is a new deployment or you already use an external database (`postgresql.enabled=false`), these changes **do not affect you**!
+* If this is an upgrade and you are using the default PostgreSQL (`postgresql.enabled=true`), you need to pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true
+
 ## [3.5.0] - Jun 22, 2020
 * Update Xray to version `3.5.2` - https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.5.2
 * Update alpine to version `3.12`

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 3.5.0
+version: 4.0.0
 appVersion: 3.5.2
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -8,7 +8,7 @@
 
 This chart will do the following:
 
-* Optionally deploy PostgreSQL
+* Optionally deploy PostgreSQL **NOTE:** For production grade installations it is recommended to use an external PostgreSQL
 * Deploy RabbitMQ (optionally as an HA cluster)
 * Deploy JFrog Xray micro-services
 

--- a/stable/xray/ci/default-values.yaml
+++ b/stable/xray/ci/default-values.yaml
@@ -1,5 +1,6 @@
 # Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.
 # If this is an upgrade over an existing Xray 3.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade.
 unifiedUpgradeAllowed: true
+databaseUpgradeReady: true
 xray:
   jfrogUrl: http://artifactory-artifactory.rt:8082

--- a/stable/xray/ci/test-values.yaml
+++ b/stable/xray/ci/test-values.yaml
@@ -1,19 +1,13 @@
 # CI values for Xray
-
-# rbac:
-#   create: false
-#
-# serviceAccount:
-#   create: false
-
 # If this is an upgrade over an existing Xray 3.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade.
 unifiedUpgradeAllowed: true
+databaseUpgradeReady: true
 xray:
   jfrogUrl: http://artifactory-artifactory.rt:8082
 
 postgresql:
-  postgresDatabase: xraydb
-  postgresUser: xray
+  postgressqlDatabase: xraydb
+  postgresqlUser: xray
   postgresqlPassword: xray
   persistence:
     enabled: false

--- a/stable/xray/requirements.lock
+++ b/stable/xray/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 8.7.3
 - name: rabbitmq-ha
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.44.2
+  version: 1.46.4
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 6.25.2
-digest: sha256:ddf4f30eb50f548ad107536a1b0880f16513062c07cc5e4e13a06ade2cc0117d
-generated: "2020-04-13T17:34:24.057841+05:30"
+  version: 7.3.3
+digest: sha256:77ceec7b9a027d9aff308c76da9c0d36cb65cd93d819b9b7dced475bb0341dbb
+generated: "2020-06-29T16:31:12.737871+05:30"

--- a/stable/xray/requirements.yaml
+++ b/stable/xray/requirements.yaml
@@ -4,10 +4,10 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: rabbitmq-ha
-  version: 1.44.2
+  version: 1.46.4
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: rabbitmq-ha.enabled
 - name: rabbitmq
-  version: 6.25.2
+  version: 7.3.3
   repository: https://charts.bitnami.com/bitnami
   condition: rabbitmq.enabled

--- a/stable/xray/templates/xray-statefulset.yaml
+++ b/stable/xray/templates/xray-statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
 {{- if .Release.IsUpgrade }}
     unifiedUpgradeAllowed: {{ required "\n\n**************************************\nSTOP! UPGRADE from Xray 2.x (appVersion) currently not supported!\nIf this is an upgrade over an existing Xray 3.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade.\n**************************************\n" .Values.unifiedUpgradeAllowed | quote }}
 {{- end }}
+{{- if and .Release.IsUpgrade .Values.postgresql.enabled }}
+    databaseUpgradeReady: {{ required "\n\n*********\nIMPORTANT: UPGRADE STOPPED to prevent data loss!\nReview CHANGELOG.md (https://github.com/jfrog/charts/blob/master/stable/xray/CHANGELOG.md), pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true if you are upgrading from chart version which has postgresql version 9.6.x." .Values.databaseUpgradeReady | quote }}
+{{- end }}
 spec:
   serviceName: "{{ template "xray.fullname" . }}"
   replicas: {{ .Values.replicaCount }}

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -203,8 +203,7 @@ rabbitmq-ha:
   enabled: true
   replicaCount: 1
   image:
-    repository: docker.bintray.io/rabbitmq
-    tag: 3.8.5-alpine
+    tag: 3.7.21-alpine
   rabbitmqUsername: guest
   rabbitmqPassword: ""
   ## Alternatively, you can use a pre-existing secret with a key called rabbitmq-password by specifying existingSecret

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -203,7 +203,8 @@ rabbitmq-ha:
   enabled: true
   replicaCount: 1
   image:
-    tag: 3.7.21-alpine
+    repository: docker.bintray.io/rabbitmq
+    tag: 3.8.5-alpine
   rabbitmqUsername: guest
   rabbitmqPassword: ""
   ## Alternatively, you can use a pre-existing secret with a key called rabbitmq-password by specifying existingSecret
@@ -251,7 +252,9 @@ rabbitmq:
   replicas: 1
   rbacEnabled: true
   image:
-    tag: 3.7.19
+    registry: docker.bintray.io
+    repository: bitnami/rabbitmq
+    tag: 3.8.5-debian-10-r14
   rabbitmq:
     username: guest
     password: ""

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -4,7 +4,7 @@
 # Access the values with {{ .Values.key.subkey }}
 
 # General
-initContainerImage: "alpine:3.12"
+initContainerImage: docker.bintray.io/alpine:3.12
 imagePullPolicy: IfNotPresent
 imagePullSecrets:
 
@@ -152,7 +152,7 @@ postgresql:
   image:
     registry: docker.bintray.io
     repository: bitnami/postgresql
-    tag: 9.6.18-debian-10-r7
+    tag: 10.13.0-debian-10-r38
   postgresqlUsername: xray
   postgresqlPassword: ""
   postgresqlDatabase: xraydb


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
* Update postgresql tag version to `10.13.0-debian-10-r38`
* Update alpine tag version to `3.12`
* **IMPORTANT**
* If this is a new deployment or you already use an external database (`postgresql.enabled=false`), these changes **do not affect you**!
* If this is an upgrade and you are using the default PostgreSQL (`postgresql.enabled=true`), you need to pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true
