### PR TITLE
[mission-control] postgresql 10.x update

### DIFF
--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,14 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.0] - Jun 26, 2020
+* Update postgresql tag version to `10.13.0-debian-10-r38`
+* Update alpine tag version to `3.12`
+* Update busybox tag version to `1.31.1`
+* **IMPORTANT**
+* If this is a new deployment or you already use an external database (`postgresql.enabled=false`), these changes **do not affect you**!
+* If this is an upgrade and you are using the default PostgreSQL (`postgresql.enabled=true`), you need to pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true
+
 ## [3.4.7] -  Jun 17, 2020
 * Added support for javaopts via systemyaml
 

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 home: https://jfrog.com/mission-control/
-version: 3.4.7
+version: 4.0.0
 appVersion: 4.4.2
 description: A Helm chart for JFrog Mission Control
 sources:

--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -7,7 +7,7 @@
 ## Chart Details
 This chart will do the following:
 
-* Deploy PostgreSQL database.
+* Deploy PostgreSQL database **NOTE:** For production grade installations it is recommended to use an external PostgreSQL.
 * Deploy Elasticsearch.
 * Deploy Mission Control.
 

--- a/stable/mission-control/ci/default-values.yaml
+++ b/stable/mission-control/ci/default-values.yaml
@@ -1,5 +1,6 @@
 # Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.
 # If this is an upgrade over an existing Mission Control 4.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade
 unifiedUpgradeAllowed: true
+databaseUpgradeReady: true
 missionControl:
   jfrogUrl: http://artifactory-artifactory.rt:8082

--- a/stable/mission-control/ci/test-values.yaml
+++ b/stable/mission-control/ci/test-values.yaml
@@ -2,6 +2,7 @@
 
 # If this is an upgrade over an existing Mission Control 4.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade
 unifiedUpgradeAllowed: true
+databaseUpgradeReady: true
 missionControl:
   jfrogUrl: http://artifactory-artifactory.rt:8082
   image:

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- if .Release.IsUpgrade }}
     unifiedUpgradeAllowed: {{ required "\n\n**************************************\nSTOP! UPGRADE from Mission Control 3.x currently not supported!\nIf this is an upgrade over an existing Mission Control 4.x, explicitly pass 'unifiedUpgradeAllowed=true' to upgrade.\n**************************************\n" .Values.unifiedUpgradeAllowed | quote }}
   {{- end }}
+  {{- if and .Release.IsUpgrade .Values.postgresql.enabled }}
+    databaseUpgradeReady: {{ required "\n\n*********\nIMPORTANT: UPGRADE STOPPED to prevent data loss!\nReview CHANGELOG.md (https://github.com/jfrog/charts/blob/master/stable/distribution/CHANGELOG.md), pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true if you are upgrading from chart version which has postgresql version 9.6.x." .Values.databaseUpgradeReady | quote }}
+  {{- end }}
 spec:
   serviceName: {{ template "mission-control.fullname" . }}
   replicas: {{ .Values.replicaCount }}

--- a/stable/mission-control/values.yaml
+++ b/stable/mission-control/values.yaml
@@ -83,7 +83,7 @@ serviceAccount:
 dbSetup:
   postgresql:
     image:
-      repository: docker.io/postgres
+      repository: docker.bintray.io/postgres
       tag: 10.13-alpine
       pullPolicy: IfNotPresent
 

--- a/stable/mission-control/values.yaml
+++ b/stable/mission-control/values.yaml
@@ -4,7 +4,7 @@
 # Access the values with {{ .Values.key.subkey }}
 
 # Common
-initContainerImage: "alpine:3.11"
+initContainerImage: docker.bintray.io/alpine:3.12
 # Init containers
 initContainers:
   resources: {}
@@ -83,8 +83,8 @@ serviceAccount:
 dbSetup:
   postgresql:
     image:
-      repository: postgres
-      tag: 9.6.18-alpine
+      repository: docker.io/postgres
+      tag: 10.13-alpine
       pullPolicy: IfNotPresent
 
 # PostgreSQL
@@ -96,7 +96,7 @@ postgresql:
   image:
     registry: docker.bintray.io
     repository: bitnami/postgresql
-    tag: 9.6.18-debian-10-r7
+    tag: 10.13.0-debian-10-r38
   postgresqlUsername: postgres
   postgresqlPassword: ""
   postgresqlDatabase: mission_control
@@ -164,7 +164,7 @@ database:
 elasticsearch:
   enabled: true
   name: elasticsearch
-  initContainerImage: "alpine:3.11"
+  initContainerImage: docker.bintray.io/alpine:3.12
   configureDockerHost: true
   image:
     repository: docker.bintray.io/jfrog/elasticsearch-oss
@@ -220,8 +220,8 @@ applicationConfigs: {}
 
 logger:
   image:
-    repository: "busybox"
-    tag: "1.30"
+    repository: docker.bintray.io/busybox
+    tag: 1.31.1
 
 missionControl:
   name: mission-control


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

* Update postgresql tag version to `10.13.0-debian-10-r38`
* Update alpine tag version to `3.12`
* Update busybox tag version to `1.31.1`
* **IMPORTANT**
* If this is a new deployment or you already use an external database (`postgresql.enabled=false`), these changes **do not affect you**!
* If this is an upgrade and you are using the default PostgreSQL (`postgresql.enabled=true`), you need to pass postgresql.image.tag=9.6.18-debian-10-r7 and databaseUpgradeReady=true