### PR TITLE
[xray][preunified]Added compatability to support latest 7.x rabbitmq subchart when rabbitmq.enabled=true

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,10 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.2.1] - Jul 1, 2020
+* Ingress version fix for k8s >= 1.14
+* Replaced `rabbbitmq.rabbitmq` tag with `rabbbitmq.auth` in values.yaml to support latest rabbitmq subchart.
+
 ## [2.2.0] - Jun 29, 2020
 * Update Xray version to 2.14.0 - https://www.jfrog.com/confluence/display/XRAY2X/Release+Notes#ReleaseNotes-Xray2.14.0
 * Update RabbitMQ chart to v7.3.3

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -3,8 +3,11 @@ All changes to this chart will be documented in this file.
 
 ## [2.2.1] - Jul 2, 2020
 * Add support for Ingress version - `networking.k8s.io/v1beta1` for k8s >= 1.14 using helm v3
-* Fixed `rabbitmq.rabbitmq` tag with `rabbitmq.auth` in values.yaml to support latest rabbitmq subchart when `rabbitmq.enabled=true`
+* Added compatability to support latest 7.x rabbitmq subchart when `rabbitmq.enabled=true`
 * Update RabbitMQ chart to v7.4.3
+* **IMPORTANT**
+* RabbitMQ 7.x chart is [not compatible](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq#to-700) with previous rabbitmq 6.x chart in previous Xray 2.x charts
+* Please refer [here](https://github.com/jfrog/charts/blob/pre-unified-platform/stable/xray/README.md#special-upgrade-notes) for upgrade notes
 
 ## [2.2.0] - Jun 29, 2020
 * Update Xray version to 2.14.0 - https://www.jfrog.com/confluence/display/XRAY2X/Release+Notes#ReleaseNotes-Xray2.14.0

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,9 +1,10 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [2.2.1] - Jul 1, 2020
+## [2.2.1] - Jul 2, 2020
 * Add support for Ingress version - `networking.k8s.io/v1beta1` for k8s >= 1.14 using helm v3
 * Fixed `rabbitmq.rabbitmq` tag with `rabbitmq.auth` in values.yaml to support latest rabbitmq subchart when `rabbitmq.enabled=true`
+* Update RabbitMQ chart to v7.4.3
 
 ## [2.2.0] - Jun 29, 2020
 * Update Xray version to 2.14.0 - https://www.jfrog.com/confluence/display/XRAY2X/Release+Notes#ReleaseNotes-Xray2.14.0

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2.2.1] - Jul 1, 2020
 * Add support for Ingress version - `networking.k8s.io/v1beta1` for k8s >= 1.14 using helm v3
-* Fixed `rabbbitmq.rabbitmq` tag with `rabbbitmq.auth` in values.yaml to support latest rabbitmq subchart when `rabbitmq.enabled=true`
+* Fixed `rabbitmq.rabbitmq` tag with `rabbitmq.auth` in values.yaml to support latest rabbitmq subchart when `rabbitmq.enabled=true`
 
 ## [2.2.0] - Jun 29, 2020
 * Update Xray version to 2.14.0 - https://www.jfrog.com/confluence/display/XRAY2X/Release+Notes#ReleaseNotes-Xray2.14.0

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -2,8 +2,8 @@
 All changes to this chart will be documented in this file.
 
 ## [2.2.1] - Jul 1, 2020
-* Ingress version fix for k8s >= 1.14
-* Replaced `rabbbitmq.rabbitmq` tag with `rabbbitmq.auth` in values.yaml to support latest rabbitmq subchart.
+* Add support for Ingress version - `networking.k8s.io/v1beta1` for k8s >= 1.14 using helm v3
+* Fixed `rabbbitmq.rabbitmq` tag with `rabbbitmq.auth` in values.yaml to support latest rabbitmq subchart when `rabbitmq.enabled=true`
 
 ## [2.2.0] - Jun 29, 2020
 * Update Xray version to 2.14.0 - https://www.jfrog.com/confluence/display/XRAY2X/Release+Notes#ReleaseNotes-Xray2.14.0

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.14.0
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -88,6 +88,15 @@ helm upgrade --name xray jfrog/xray \
     --set postgresql.postgresqlPassword=${POSTGRES_PASSWORD}
 ```
 
+## Special Upgrade Notes:
+
+While upgrading from Xray 2.x to 2.x charts due to breaking changes, use kubectl delete statefulsets <old_statefulset_xray_name> and run helm upgrade
+
+Also, While upgrading from Xray 2.x to 2.x charts due to breaking rabbitmq (when `rabbitmq.enabled=true`) subchart changes,
+
+1. Use kubectl delete statefulsets <old_statefulset_rabbitmq_name> <old_statefulset_xray_name>
+2. Use kubectl delete pvc <old_statefulset_rabbitmq_name> and run helm upgrade
+
 ## Remove
 Removing a **helm** release is done with
 ```bash

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -295,17 +295,17 @@ The following table lists the configurable parameters of the xray chart and thei
 | `mongodb.affinity`                             | Mongodb node affinity                        | `{}`                 |
 | `mongodb.tolerations`                          | Mongodb node tolerations                     | `[]`                 |
 | `rabbitmq.enabled`                             | RabbitMQ enabled uses rabbitmq               | `false`              |
-| `rabbitmq.replicas`                            | RabbitMQ replica count               | `1`              |
-| `rabbitmq.rbacEnabled`                         | If true, create & use RBAC resources         | `true`               |
+| `rabbitmq.replicaCount`                        | RabbitMQ replica count                       | `1`              |
+| `rabbitmq.rbac.create`                         | If true, create & use RBAC resources         | `true`               |
 | `rabbitmq.auth.username`                       | RabbitMQ application username                | `guest`               |
 | `rabbitmq.auth.password`                       | RabbitMQ application password                |                |
 | `rabbitmq.auth.existingPasswordSecret`         | RabbitMQ existingPasswordSecret              |                |
 | `rabbitmq.auth.erlangCookie`                   | RabbitMQ Erlang cookie                       | `XRAYRABBITMQCLUSTER`|
 | `rabbitmq.auth.existingErlangSecret`           | RabbitMQ existingErlangSecret                |                |
-| `rabbitmq.service.nodePort`                    | RabbitMQ node port                           | `5672`               |
-| `rabbitmq.persistence.enabled`            | If `true`, persistent volume claims are created | `true`            |
-| `rabbitmq.persistence.accessMode`            | RabbitMQ persistent volume claims access mode | `ReadWriteOnce`            |
-| `rabbitmq.persistence.size`               | RabbitMQ Persistent volume size              | `20Gi`               |
+| `rabbitmq.service.port`                        | RabbitMQ node port                           | `5672`               |
+| `rabbitmq.persistence.enabled`                 | If `true`, persistent volume claims are created | `true`            |
+| `rabbitmq.persistence.accessMode`              | RabbitMQ persistent volume claims access mode | `ReadWriteOnce`            |
+| `rabbitmq.persistence.size`                    | RabbitMQ Persistent volume size              | `20Gi`               |
 | `rabbitmq-ha.enabled`                          | RabbitMQ enabled uses rabbitmq-ha            | `true`               |
 | `rabbitmq-ha.replicaCount`                     | RabbitMQ Number of replica                   | `1`                  |
 | `rabbitmq-ha.rabbitmqUsername`                 | RabbitMQ application username                | `guest`              |

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -95,7 +95,7 @@ While upgrading from Xray 2.x to 2.x charts due to breaking changes, use kubectl
 Also, While upgrading from Xray 2.x to 2.x charts due to breaking rabbitmq (when `rabbitmq.enabled=true`) subchart changes,
 
 1. Use kubectl delete statefulsets <old_statefulset_rabbitmq_name> <old_statefulset_xray_name>
-2. Use kubectl delete pvc <old_statefulset_rabbitmq_name> and run helm upgrade
+2. Use kubectl delete pvc <old_PVC_rabbitmq_name> and run helm upgrade
 
 ## Remove
 Removing a **helm** release is done with

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -297,10 +297,11 @@ The following table lists the configurable parameters of the xray chart and thei
 | `rabbitmq.enabled`                             | RabbitMQ enabled uses rabbitmq               | `false`              |
 | `rabbitmq.replicas`                            | RabbitMQ replica count               | `1`              |
 | `rabbitmq.rbacEnabled`                         | If true, create & use RBAC resources         | `true`               |
-| `rabbitmq.rabbitmq.username`                    | RabbitMQ application username                | `guest`               |
-| `rabbitmq.rabbitmq.password`                    | RabbitMQ application password                |                |
-| `rabbitmq.rabbitmq.existingPasswordSecret`      | RabbitMQ existingPasswordSecret               |                |
-| `rabbitmq.rabbitmq.erlangCookie`                | RabbitMQ Erlang cookie                       | `XRAYRABBITMQCLUSTER`|
+| `rabbitmq.auth.username`                       | RabbitMQ application username                | `guest`               |
+| `rabbitmq.auth.password`                       | RabbitMQ application password                |                |
+| `rabbitmq.auth.existingPasswordSecret`         | RabbitMQ existingPasswordSecret              |                |
+| `rabbitmq.auth.erlangCookie`                   | RabbitMQ Erlang cookie                       | `XRAYRABBITMQCLUSTER`|
+| `rabbitmq.auth.existingErlangSecret`           | RabbitMQ existingErlangSecret                |                |
 | `rabbitmq.service.nodePort`                    | RabbitMQ node port                           | `5672`               |
 | `rabbitmq.persistence.enabled`            | If `true`, persistent volume claims are created | `true`            |
 | `rabbitmq.persistence.accessMode`            | RabbitMQ persistent volume claims access mode | `ReadWriteOnce`            |

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -30,7 +30,7 @@ helm repo add jfrog https://charts.jfrog.io
 ### Install Chart
 Install JFrog Xray
 ```bash
-helm upgrade --install xray --namespace xray jfrog/xray --version 2.2.0
+helm upgrade --install xray --namespace xray jfrog/xray --version 2.2.1
 ```
 
 ## Status

--- a/stable/xray/ci/default-values.yaml
+++ b/stable/xray/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.
+databaseUpgradeReady: true

--- a/stable/xray/ci/test-rabbitmq-default-values.yaml
+++ b/stable/xray/ci/test-rabbitmq-default-values.yaml
@@ -1,0 +1,8 @@
+# CI values for Xray
+databaseUpgradeReady: true
+
+rabbitmq-ha:
+  enabled: false
+
+rabbitmq:
+  enabled: true

--- a/stable/xray/ci/test-rabbitmq-values.yaml
+++ b/stable/xray/ci/test-rabbitmq-values.yaml
@@ -1,12 +1,11 @@
 # CI values for Xray
-
+databaseUpgradeReady: true
 rbac:
   create: false
 
 serviceAccount:
   create: false
 
-databaseUpgradeReady: yes
 analysis:
   loggers:
     - xray_analysis.log
@@ -39,11 +38,10 @@ mongodb:
     enabled: false
 
 rabbitmq-ha:
-    enabled: false
+  enabled: false
 
 rabbitmq:
   enabled: true
   auth:
     username: guest
     password: password
-    

--- a/stable/xray/ci/test-rabbitmq-values.yaml
+++ b/stable/xray/ci/test-rabbitmq-values.yaml
@@ -39,7 +39,11 @@ mongodb:
     enabled: false
 
 rabbitmq-ha:
-  rabbitmqUsername: guest
-  rabbitmqPassword: guest
-  persistentVolume:
-    enabled: true
+    enabled: false
+
+rabbitmq:
+  enabled: true
+  auth:
+    username: guest
+    password: password
+    

--- a/stable/xray/ci/test-values.yaml
+++ b/stable/xray/ci/test-values.yaml
@@ -41,4 +41,4 @@ rabbitmq-ha:
   rabbitmqUsername: guest
   rabbitmqPassword: guest
   persistentVolume:
-    enabled: true
+    enabled: false

--- a/stable/xray/ci/test-values.yaml
+++ b/stable/xray/ci/test-values.yaml
@@ -1,12 +1,11 @@
 # CI values for Xray
-
+databaseUpgradeReady: true
 rbac:
   create: false
 
 serviceAccount:
   create: false
 
-databaseUpgradeReady: yes
 analysis:
   loggers:
     - xray_analysis.log

--- a/stable/xray/requirements.lock
+++ b/stable/xray/requirements.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 1.46.4
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 7.3.3
+  version: 7.4.3
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
   version: 7.14.8
-digest: sha256:40548fc8290c20694bc36ed14c362ed08b469c955071f6b2a8d86cbec5ed2eee
-generated: "2020-06-29T16:39:50.99178+05:30"
+digest: sha256:f5145d5bd31e0630e76d82f96b06ca2457a6cca95ba0e25f5945033119a76fc7
+generated: "2020-07-02T12:36:10.71492+05:30"

--- a/stable/xray/requirements.yaml
+++ b/stable/xray/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: rabbitmq-ha.enabled
 - name: rabbitmq
-  version: 7.3.3
+  version: 7.4.3
   repository: https://charts.bitnami.com/bitnami
   condition: rabbitmq.enabled
 - name: mongodb

--- a/stable/xray/templates/ingress.yaml
+++ b/stable/xray/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "xray-server.fullname" . -}}
 {{- $servicePort := .Values.server.externalPort -}}
-{{- if semverCompare ">=v1.14.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=v1.14.0" .Capabilities.KubeVersion.Version }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/stable/xray/templates/xray-analysis-statefulset.yaml
+++ b/stable/xray/templates/xray-analysis-statefulset.yaml
@@ -99,7 +99,7 @@ spec:
         {{- end }}
         {{ if index .Values "rabbitmq" "enabled" }}
         - name: RABBITMQ_USER
-          value: {{ .Values.rabbitmq.rabbitmq.username }}
+          value: {{ .Values.rabbitmq.auth.username }}
         - name: RABBITMQ_ERLANG_COOKIE
           valueFrom:
             secretKeyRef:

--- a/stable/xray/templates/xray-indexer-statefulset.yaml
+++ b/stable/xray/templates/xray-indexer-statefulset.yaml
@@ -99,7 +99,7 @@ spec:
         {{- end }}
         {{ if index .Values "rabbitmq" "enabled" }}
         - name: RABBITMQ_USER
-          value: {{ .Values.rabbitmq.rabbitmq.username }}
+          value: {{ .Values.rabbitmq.auth.username }}
         - name: RABBITMQ_ERLANG_COOKIE
           valueFrom:
             secretKeyRef:

--- a/stable/xray/templates/xray-persist-statefulset.yaml
+++ b/stable/xray/templates/xray-persist-statefulset.yaml
@@ -99,7 +99,7 @@ spec:
         {{- end }}
         {{ if index .Values "rabbitmq" "enabled" }}
         - name: RABBITMQ_USER
-          value: {{ .Values.rabbitmq.rabbitmq.username }}
+          value: {{ .Values.rabbitmq.auth.username }}
         - name: RABBITMQ_ERLANG_COOKIE
           valueFrom:
             secretKeyRef:

--- a/stable/xray/templates/xray-server-statefulset.yaml
+++ b/stable/xray/templates/xray-server-statefulset.yaml
@@ -99,7 +99,7 @@ spec:
         {{- end }}
         {{ if index .Values "rabbitmq" "enabled" }}
         - name: RABBITMQ_USER
-          value: {{ .Values.rabbitmq.rabbitmq.username }}
+          value: {{ .Values.rabbitmq.auth.username }}
         - name: RABBITMQ_ERLANG_COOKIE
           valueFrom:
             secretKeyRef:

--- a/stable/xray/templates/xray-setup-conf.yaml
+++ b/stable/xray/templates/xray-setup-conf.yaml
@@ -47,7 +47,7 @@ data:
     until nc -z -w 2 {{ .Release.Name }}-rabbitmq-ha {{ index .Values "rabbitmq-ha" "rabbitmqNodePort" }} && echo rabbitmq ok; do
     {{- end }}
     {{ if index .Values "rabbitmq" "enabled" }}
-    until nc -z -w 2 {{ .Release.Name }}-rabbitmq {{ .Values.rabbitmq.service.nodePort }} && echo rabbitmq ok; do
+    until nc -z -w 2 {{ .Release.Name }}-rabbitmq {{ .Values.rabbitmq.service.port }} && echo rabbitmq ok; do
     {{- end }}
       sleep 2;
     done;
@@ -78,7 +78,7 @@ data:
     RABBITMQ_URL="amqp://${RABBITMQ_USER}:${RABBITMQ_DEFAULT_PASS}@{{ .Release.Name }}-rabbitmq-ha:{{ index .Values "rabbitmq-ha" "rabbitmqNodePort" }}/"
     {{- end }}
     {{ if index .Values "rabbitmq" "enabled" }}
-    RABBITMQ_URL="amqp://${RABBITMQ_USER}:${RABBITMQ_DEFAULT_PASS}@{{ .Release.Name }}-rabbitmq:{{ .Values.rabbitmq.service.nodePort }}/"
+    RABBITMQ_URL="amqp://${RABBITMQ_USER}:${RABBITMQ_DEFAULT_PASS}@{{ .Release.Name }}-rabbitmq:{{ .Values.rabbitmq.service.port }}/"
     {{- end }}
     cp -vf ${SCRIPTS_DIR}/xray_config.yaml ${XRAY_CONFIG_FILE}
 

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -230,8 +230,9 @@ rabbitmq-ha:
 ##
 rabbitmq:
   enabled: false
-  replicas: 1
-  rbacEnabled: true
+  replicaCount: 1
+  rbac:
+    create: true
   image:
     registry: docker.bintray.io
     repository: bitnami/rabbitmq
@@ -244,7 +245,7 @@ rabbitmq:
     erlangCookie: XRAYRABBITMQCLUSTER
     # existingErlangSecret: <name-of-existing-secret>
   service:
-    nodePort: 5672
+    port: 5672
   persistence:
     enabled: true
     accessMode: ReadWriteOnce

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -236,12 +236,13 @@ rabbitmq:
     registry: docker.bintray.io
     repository: bitnami/rabbitmq
     tag: 3.8.5-debian-10-r14
-  rabbitmq:
+  auth:
     username: guest
     password: ""
     ## Alternatively, you can use a pre-existing secret with a key called rabbitmq-password by specifying existingPasswordSecret
     # existingPasswordSecret: <name-of-existing-secret>
     erlangCookie: XRAYRABBITMQCLUSTER
+    # existingErlangSecret: <name-of-existing-secret>
   service:
     nodePort: 5672
   persistence:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
* Added compatability to support latest 7.x rabbitmq subchart when `rabbitmq.enabled=true`
* Update RabbitMQ chart to v7.4.3
* **IMPORTANT**
* RabbitMQ 7.x chart is [not compatible](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq#to-700) with previous rabbitmq 6.x chart in previous Xray 2.x charts
* Please refer [here](https://github.com/jfrog/charts/blob/pre-unified-platform/stable/xray/README.md#special-upgrade-notes) for upgrade notes
* Add support for Ingress version - `networking.k8s.io/v1beta1` for k8s >= 1.14 using helm v3

**Other info :**

* the networking.k8s.io/v1beta1.Ingress kind was introduced in Kubernetes 1.14.
* the extensions/v1beta1.Ingress kind is deprecated but will not be removed until Kubernetes 1.20 (unless it slips again).
* we know we have users running versions < Kubernetes 1.14