### PR TITLE
[xray] Move postgresql values fields to correct place in Xray Helm chart

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.1.1] - Jun 12, 2020
+* Move some postgresql values to where they should be according to the subchart.
+
 ## [4.1.0] - Jul 9, 2020
 * Update Xray to version `3.6.2` - https://www.jfrog.com/confluence/display/JFROG/Xray+Release+Notes#XrayReleaseNotes-Xray3.6.2
 * Update rabbitmq-ha tag version to 3.8.5-alpine

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [4.1.1] - Jun 12, 2020
+## [4.1.1] - Jul 10, 2020
 * Move some postgresql values to where they should be according to the subchart.
 
 ## [4.1.0] - Jul 9, 2020

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 4.1.0
+version: 4.1.1
 appVersion: 3.6.2
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -323,9 +323,12 @@ The following table lists the configurable parameters of the xray chart and thei
 | `postgresql.resources.requests.cpu`       | PostgreSQL initial cpu request      |                                    |
 | `postgresql.resources.limits.memory`      | PostgreSQL memory limit             |                                    |
 | `postgresql.resources.limits.cpu`         | PostgreSQL cpu limit                |                                    |
-| `postgresql.nodeSelector`                 | PostgreSQL node selector            | `{}`                               |
-| `postgresql.affinity`                     | PostgreSQL node affinity            | `{}`                               |
-| `postgresql.tolerations`                  | PostgreSQL node tolerations         | `[]`                               |
+| `postgresql.master.nodeSelector`                 | PostgreSQL master node selector            | `{}`                               |
+| `postgresql.master.affinity`                     | PostgreSQL master node affinity            | `{}`                               |
+| `postgresql.master.tolerations`                  | PostgreSQL master node tolerations         | `[]`                               |
+| `postgresql.slave.nodeSelector`                 | PostgreSQL slave node selector            | `{}`                               |
+| `postgresql.slave.affinity`                     | PostgreSQL slave node affinity            | `{}`                               |
+| `postgresql.slave.tolerations`                  | PostgreSQL slave node tolerations         | `[]`                               |
 | `database.url`                            | External database connection URL                   |                                         |
 | `database.user`                           | External database username                         |                                         |
 | `database.password`                       | External database password                         |                                         |

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -165,6 +165,14 @@ postgresql:
     enabled: true
     size: 50Gi
     existingClaim:
+  master:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  slave:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
   resources: {}
   #  requests:
   #    memory: "1Gi"
@@ -172,9 +180,6 @@ postgresql:
   #  limits:
   #    memory: "2Gi"
   #    cpu: "1"
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
 database:


### PR DESCRIPTION
Postgresql has nodeSelector, affinity and tolerations under master and slave.
Having this in the incorrect place in the Values.yaml file makes it
confusing for people trying to use the chart.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:
This change is functionally a no-op change. It moves some default postgresql parameters to their correct places. Having the incorrect values is confusing for people deploying the chart because changing the values as they were documented wouldn't actually change anything in the final rendered manifest.

**Special notes for your reviewer**:
Artifactory, Artifactory-ha and mission-control also have this exact problem, I'll submit PRs for those as soon as we've finished this one.