### PR TITLE
[artifactory] Fix postgresql values based on postgresql subchart

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.0.4] - Jul 8, 2020
+* Move some postgresql values to where they should be according to the subchart
+
 ## [3.0.3] - Jul 8, 2020
 * Set Artifactory access client connections to the same value as the access threads.
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 3.0.3
+version: 3.0.4
 appVersion: 7.6.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -1320,6 +1320,12 @@ The following table lists the configurable parameters of the artifactory chart a
 | `postgresql.resources.requests.cpu`       | PostgreSQL initial cpu request     |                                         |
 | `postgresql.resources.limits.memory`      | PostgreSQL memory limit            |                                         |
 | `postgresql.resources.limits.cpu`         | PostgreSQL cpu limit               |                                         |
+| `postgresql.master.nodeSelector`          | PostgreSQL master node selector    | `{}`                               |
+| `postgresql.master.affinity`              | PostgreSQL master node affinity    | `{}`                               |
+| `postgresql.master.tolerations`           | PostgreSQL master node tolerations | `[]`                               |
+| `postgresql.slave.nodeSelector`           | PostgreSQL slave node selector     | `{}`                               |
+| `postgresql.slave.affinity`               | PostgreSQL slave node affinity     | `{}`                               |
+| `postgresql.slave.tolerations`            | PostgreSQL slave node tolerations  | `[]`                               |
 | `database.type`                  | External database type (`postgresql`, `mysql`, `oracle` or `mssql`)  |                       |
 | `database.driver`                | External database driver e.g. `org.postgresql.Driver`  |                       |
 | `database.url`                   | External database connection URL                   |                                         |

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -114,6 +114,14 @@ postgresql:
     size: 50Gi
   service:
     port: 5432
+  master:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  slave:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
   resources: {}
   #  requests:
   #    memory: "512Mi"
@@ -121,7 +129,6 @@ postgresql:
   #  limits:
   #    memory: "1Gi"
   #    cpu: "500m"
-  nodeSelector: {}
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
 ## you MUST specify custom database details here or Artifactory will NOT start

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [10.0.4] - Jul 10, 2020
+* Move some postgresql values to where they should be according to the subchart
+
 ## [10.0.3] - Jul 8, 2020
 * Set Artifactory access client connections to the same value as the access threads
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 10.0.3
+version: 10.0.4
 appVersion: 7.6.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -1156,6 +1156,12 @@ The following table lists the configurable parameters of the artifactory chart a
 | `postgresql.resources.requests.cpu`       | PostgreSQL initial cpu request     |                                         |
 | `postgresql.resources.limits.memory`      | PostgreSQL memory limit            |                                         |
 | `postgresql.resources.limits.cpu`         | PostgreSQL cpu limit               |                                         |
+| `postgresql.master.nodeSelector`                 | PostgreSQL master node selector            | `{}`                               |
+| `postgresql.master.affinity`                     | PostgreSQL master node affinity            | `{}`                               |
+| `postgresql.master.tolerations`                  | PostgreSQL master node tolerations         | `[]`                               |
+| `postgresql.slave.nodeSelector`                 | PostgreSQL slave node selector            | `{}`                               |
+| `postgresql.slave.affinity`                     | PostgreSQL slave node affinity            | `{}`                               |
+| `postgresql.slave.tolerations`                  | PostgreSQL slave node tolerations         | `[]`                               |
 | `database.type`                  | External database type (`postgresql`, `mysql`, `oracle` or `mssql`)  |                       |
 | `database.driver`                  | External database driver e.g. `org.postgresql.Driver`  |                       |
 | `database.url`                   | External database connection URL                   |                                         |

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -1147,6 +1147,14 @@ postgresql:
     size: 50Gi
   service:
     port: 5432
+  master:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  slave:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
   resources: {}
   #  requests:
   #    memory: "512Mi"
@@ -1154,7 +1162,6 @@ postgresql:
   #  limits:
   #    memory: "1Gi"
   #    cpu: "500m"
-  nodeSelector: {}
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
 ## specify custom database details here or leave empty and Artifactory will use embedded derby


### PR DESCRIPTION
Postgresql has nodeSelector, affinity and tolerations under master and slave.
Having this in the incorrect place in the Values.yaml file makes it
confusing for people trying to use the chart.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:
This change is functionally a no-op change. It moves some default postgresql parameters to their correct places. Having the incorrect values is confusing for people deploying the chart because changing the values as they were documented wouldn't actually change anything in the final rendered manifest.

**Special notes for your reviewer**:
This change is almost identical to #1005 