### PR TITLE
[artifactory] Create database secrets if postgres password is set

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [11.0.2] - Sep 16, 2020
+* Create database secrets if password is set
+
 ## [11.0.1] - Sep 14, 2020
 * Updated Artifactory version to 7.7.8 - [Release Notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.7.8)
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 11.0.1
+version: 11.0.2
 appVersion: 7.7.8
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-database-secrets.yaml
+++ b/stable/artifactory/templates/artifactory-database-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if and  (not .Values.database.secrets) (not .Values.postgresql.enabled) }}
+{{- if or (and  (not .Values.database.secrets) (not .Values.postgresql.enabled)) .Values.database.password }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -429,6 +429,9 @@ artifactory:
         url: "jdbc:postgresql://{{ .Release.Name }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.postgresqlDatabase }}"
         driver: org.postgresql.Driver
         username: "{{ .Values.postgresql.postgresqlUsername }}"
+        {{- if .Values.postgresql.postgresqlPassword }}
+        password: "{{ .Values.postgresql.postgresqlPassword }}"
+        {{- end }}
         {{- else }}
         type: "{{ .Values.database.type }}"
         driver: "{{ .Values.database.driver }}"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:
Allows user to set database password rather than use the generated one. This also works as a workaround for https://github.com/jfrog/charts/issues/859

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes 


**Special notes for your reviewer**:

