### PR TITLE
[CHARTS] Adding CLA to chart repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# JFrog welcomes community contribution!
+
+Before we can accept your contribution, process your GitHub pull requests, and thank you full-heartedly, we request that you will fill out and submit JFrog's Contributor License Agreement (CLA).
+
+[Click here](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N) to submit the JFrog CLA.
+This should only take a minute to complete and is a one-time process.
+
+*Thanks for Your Contribution to the Community!* :-)
+
+## Pull Request Process ##
+
+- Fork this repository.
+- Clone the forked repository to your local machine and perform the proposed changes. 
+- Test the changes in your own K8s environment and confirm everything works end to end.
+- Lint the charts
+- Update the chart version
+- Update the CHANGELOG.md
+- Submit a PR with the relevant information and check the applicable boxes and fill out the questions.
+
+## Acceptance Criteria ##
+
+- Pull requests must pass all automated checks
+- Chart version has been bumped
+- CHANGELOG.md has relevant changes
+- README.md has been updated if req'd
+- Three approvals from reviewers
+
+Upon the success of the above the pull request will be mergable into master branch. Upon merge the source branch will be removed.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ This should only take a minute to complete and is a one-time process.
 - Fork this repository.
 - Clone the forked repository to your local machine and perform the proposed changes. 
 - Test the changes in your own K8s environment and confirm everything works end to end.
-- Lint the charts
 - Update the chart version
 - Update the CHANGELOG.md
+- Lint the charts
 - Submit a PR with the relevant information and check the applicable boxes and fill out the questions.
 
 ## Acceptance Criteria ##
@@ -22,7 +22,7 @@ This should only take a minute to complete and is a one-time process.
 - Pull requests must pass all automated checks
 - Chart version has been bumped
 - CHANGELOG.md has relevant changes
-- README.md has been updated if req'd
+- README.md has been updated if required
 - Three approvals from reviewers
 
 Upon the success of the above the pull request will be mergable into master branch. Upon merge the source branch will be removed.


### PR DESCRIPTION
#### PR Checklist

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Adds a CLA to the repo for users to accept for contributions from the general public to sign the legal agreement first.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes all PRs coming from general public to enforce the CLA.

**Special notes for your reviewer**:

Needs to get merged prior to any other PRs like 1094 as contributors must sign the CLA prior to code merges.
