### PR TITLE
[Pipelines] Change init container to use CAP_CHOWN 

### DIFF
--- a/stable/pipelines/CHANGELOG.md
+++ b/stable/pipelines/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Pipelines Chart Changelog
 All changes to this chart to be documented in this file
 
+## [1.4.7] September 25, 2020
+* Changed init container to use linux capabilities CAP_CHOWN instead of runAsUser: 0
+
 ## [1.4.6] September 23, 2020
 * Escalated privileges to init container only for pipelines-installer to work with pipelines images as non-root based for Openshift.
 

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pipelines
 home: https://jfrog.com/pipelines/
-version: 1.4.6
+version: 1.4.7
 appVersion: 1.7.2
 description: A Helm chart for JFrog Pipelines
 sources:

--- a/stable/pipelines/templates/pipelines-statefulset.yaml
+++ b/stable/pipelines/templates/pipelines-statefulset.yaml
@@ -74,7 +74,9 @@ spec:
           imagePullPolicy: {{ .Values.pipelines.pipelinesInit.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsUser: 0
+            capabilities:
+              add:
+                - CHOWN
           env:
             - name: VAULT_TOKEN
               valueFrom:


### PR DESCRIPTION

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Cannot use runAsUser:0 in Openshift for certification with rook-cph 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
PTERNG-1120

**Special notes for your reviewer**:
Required for Pipelines to work in customers Openshift environments
