### PR TITLE
[XRAY] Router user id and group id support in values.yaml

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [6.0.7] - Oct 1, 2020
+* Added router user and group id options to values.yaml to enable running all containers in custom user or group id ranges
+
 ## [6.0.6] - Sep 30, 2020
 * Added support for resources in init containers
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 6.0.6
+version: 6.0.7
 appVersion: 3.8.8
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/templates/xray-statefulset.yaml
+++ b/stable/xray/templates/xray-statefulset.yaml
@@ -147,6 +147,8 @@ spec:
             containerPort: {{ .Values.router.internalPort }}
         securityContext:
           allowPrivilegeEscalation: false
+          runAsUser: {{ .Values.common.routerUserId }}
+          fsGroup: {{ .Values.common.routerGroupId }}
         volumeMounts:
         - name: data-volume
           mountPath: {{ .Values.router.persistence.mountPath | quote }}

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -367,6 +367,8 @@ common:
   # xrayVersion:
   xrayUserId: 1035
   xrayGroupId: 1035
+  routerUserId: 1117
+  routerGroupId: 1117
 
   # Xray configuration to be written to xray_config.yaml
   xrayConfig:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Enables support for running all xray containers in a custom user id and/or group id range. Currently we support it in 4 out of the 5 containers in the xray pod through common.xrayUserId and common.xrayGroupId in values.yaml so this adds similar functionality but for the router container.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
PTRENG-1120 required for Openshift to enable all containers to use a custom user and group id range.

**Special notes for your reviewer**:
Required for Openshift for customer fixes.
