### PR TITLE
[artifactory][artifactory-ha] value name change to correct "storageClassName"

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.1.1] - Oct 06, 2020
+* Fix `storageClass` to correct `storageClassName` in values.yaml
+
 ## [4.1.0] - Sep 30, 2020
 * Updated Artifactory version to 7.9.0 - [Release Notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.9)
 

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [4.2.0] - Oct 06, 2020
-* Fix `storageClass` to correct `storageClassName` in values.yaml
+* **Breaking change:** Fix `storageClass` to correct `storageClassName` in values.yaml
 
 ## [4.1.0] - Sep 30, 2020
 * Updated Artifactory version to 7.9.0 - [Release Notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.9)

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [4.1.1] - Oct 06, 2020
+## [4.2.0] - Oct 06, 2020
 * Fix `storageClass` to correct `storageClassName` in values.yaml
 
 ## [4.1.0] - Sep 30, 2020

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [4.3.0] - Oct 07, 2020
+* Updated Artifactory version to 7.9.1
 * **Breaking change:** Fix `storageClass` to correct `storageClassName` in values.yaml
 
 ## [4.2.0] - Oct 5, 2020

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 4.1.1
+version: 4.2.0
 appVersion: 7.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 4.1.0
+version: 4.1.1
 appVersion: 7.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
 version: 4.3.0
-appVersion: 7.9.0
+appVersion: 7.9.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.
 keywords:

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 4.2.0
+version: 4.3.0
 appVersion: 7.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/nginx-pvc.yaml
+++ b/stable/artifactory-ha/templates/nginx-pvc.yaml
@@ -15,11 +15,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.nginx.persistence.size | quote }}
-{{- if .Values.nginx.persistence.storageClass }}
-{{- if (eq "-" .Values.nginx.persistence.storageClass) }}
+{{- if .Values.nginx.persistence.storageClassName }}
+{{- if (eq "-" .Values.nginx.persistence.storageClassName) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.nginx.persistence.storageClass }}"
+  storageClassName: "{{ .Values.nginx.persistence.storageClassName }}"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,7 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
-## [11.1.1] - Oct 02, 2020
+
+## [11.1.1] - Oct 06, 2020
 * value name in values yaml changed from `storageClass` to correct `storageClassName`
 
 ## [11.1.0] - Sep 30, 2020

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [11.1.1] - Oct 06, 2020
+## [11.2.0] - Oct 06, 2020
 * Fix `storageClass` to correct `storageClassName` in values.yaml
 
 ## [11.1.0] - Sep 30, 2020

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,5 +1,7 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
+## [11.1.1] - Oct 02, 2020
+* value name form values yaml in artifactory chart changed form `storageClass` to correct `storageClassName`
 
 ## [11.1.0] - Sep 30, 2020
 * Updated Artifactory version to 7.9.0 - [Release Notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.9)

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [11.1.1] - Oct 06, 2020
-* value name in values yaml changed from `storageClass` to correct `storageClassName`
+* Fix `storageClass` to correct `storageClassName` in values.yaml
 
 ## [11.1.0] - Sep 30, 2020
 * Updated Artifactory version to 7.9.0 - [Release Notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.9)

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -2,6 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [11.3.0] - Oct 7, 2020
+* Updated Artifactory version to 7.9.1
 * **Breaking change:** Fix `storageClass` to correct `storageClassName` in values.yaml
 
 ## [11.2.0] - Oct 5, 2020

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 ## [11.1.1] - Oct 02, 2020
-* value name form values yaml in artifactory chart changed form `storageClass` to correct `storageClassName`
+* value name in values yaml changed from `storageClass` to correct `storageClassName`
 
 ## [11.1.0] - Sep 30, 2020
 * Updated Artifactory version to 7.9.0 - [Release Notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.9)

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [11.2.0] - Oct 06, 2020
-* Fix `storageClass` to correct `storageClassName` in values.yaml
+* **Breaking change:** Fix `storageClass` to correct `storageClassName` in values.yaml
 
 ## [11.1.0] - Sep 30, 2020
 * Updated Artifactory version to 7.9.0 - [Release Notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.9)

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 11.2.0
+version: 11.3.0
 appVersion: 7.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 11.1.1
+version: 11.2.0
 appVersion: 7.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
 version: 11.3.0
-appVersion: 7.9.0
+appVersion: 7.9.1
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.
 keywords:

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 11.1.0
+version: 11.1.1
 appVersion: 7.9.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/nginx-pvc.yaml
+++ b/stable/artifactory/templates/nginx-pvc.yaml
@@ -15,11 +15,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.nginx.persistence.size | quote }}
-{{- if .Values.nginx.persistence.storageClass }}
-{{- if (eq "-" .Values.nginx.persistence.storageClass) }}
+{{- if .Values.nginx.persistence.storageClassName }}
+{{- if (eq "-" .Values.nginx.persistence.storageClassName) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.nginx.persistence.storageClass }}"
+  storageClassName: "{{ .Values.nginx.persistence.storageClassName }}"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -840,7 +840,7 @@ artifactory:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    # storageClass: "-"
+    # storageClassName: "-"
     ## Annotations for the Persistent Volume Claim
     annotations: {}
   ## Uncomment the following resources definitions or pass them from command line

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -1171,7 +1171,7 @@ nginx:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    # storageClass: "-"
+    # storageClassName: "-"
   resources: {}
   #  requests:
   #    memory: "250Mi"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


**What this PR does / why we need it**:

Value name should be `storageClassName` it is mentioned few lines above in values file, if someone will not notice this litle mistake, PVC will not be assigned to target storage class 

**Special notes for your reviewer**:

