### PR TITLE
[pipelines] Changed to use custominitContainerBegin tag

### DIFF
--- a/stable/pipelines/CHANGELOG.md
+++ b/stable/pipelines/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart to be documented in this file
 
 ## [1.5.4] Oct 8, 2020
-* Changed customInitBeginContainer to customInitContainerBegin to match other charts
+* Changed customInitBeginContainer to customInitContainerBegin to match other jfrog charts
 * Added examples in values.yaml for .Values.pipelines.customInitContainerBegin
 
 ## [1.5.3] Oct 7, 2020

--- a/stable/pipelines/CHANGELOG.md
+++ b/stable/pipelines/CHANGELOG.md
@@ -1,6 +1,10 @@
 # JFrog Pipelines Chart Changelog
 All changes to this chart to be documented in this file
 
+## [1.5.4] Oct 8, 2020
+* Changed customInitBeginContainer to customInitContainerBegin to match other charts
+* Added examples in values.yaml for .Values.pipelines.customInitContainerBegin
+
 ## [1.5.3] Oct 7, 2020
 * Adding custom init begin container to pipelines statefulset and vault statefulset
 * Moved custom init container in vault statefulset from first to last position

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pipelines
 home: https://jfrog.com/pipelines/
-version: 1.5.3
+version: 1.5.4
 appVersion: 1.8.0
 description: A Helm chart for JFrog Pipelines
 sources:

--- a/stable/pipelines/templates/pipelines-statefulset.yaml
+++ b/stable/pipelines/templates/pipelines-statefulset.yaml
@@ -35,8 +35,8 @@ spec:
       - name: {{ .Values.imagePullSecrets }}
     {{- end }}
       initContainers:
-        {{- with .Values.pipelines.customInitBeginContainers }}
-        {{ tpl . $ | nindent 8 }}
+        {{- with .Values.pipelines.customInitContainersBegin }}
+        {{- tpl . $ | nindent 8 }}
         {{- end }}
         - name: copy-system-yaml
           image: "{{ .Values.initContainer.image }}"
@@ -143,7 +143,7 @@ spec:
             readOnly: true
           {{- end }}
         {{- with .Values.pipelines.customInitContainers }}
-        {{ tpl . $ | nindent 8 }}
+        {{- tpl . $ | nindent 8 }}
         {{- end }}
       containers:
         {{- if .Values.filebeat.enabled }}

--- a/stable/pipelines/templates/vault-statefulset.yaml
+++ b/stable/pipelines/templates/vault-statefulset.yaml
@@ -27,8 +27,8 @@ spec:
       - name: {{ .Values.imagePullSecrets }}
     {{- end }}
       initContainers:
-        {{- with .Values.vault.customInitBeginContainers }}
-        {{ tpl . $ | nindent 8 }}
+        {{- with .Values.vault.customInitContainersBegin }}
+        {{- tpl . $ | nindent 8 }}
         {{- end }}
         - name: config
           image: '{{ .Values.initContainer.image }}'
@@ -105,7 +105,7 @@ spec:
             mountPath: "/tmp/etc/system.yaml"
             subPath: system.yaml
         {{- with .Values.vault.customInitContainers }}
-        {{ tpl . $ | nindent 8 }}
+        {{- tpl . $ | nindent 8 }}
         {{- end }}
       containers:
         - name: vault-init

--- a/stable/pipelines/values.yaml
+++ b/stable/pipelines/values.yaml
@@ -430,7 +430,20 @@ pipelines:
   #    mountPath: /scripts/script.sh
   #    subPath: script.sh
 
-  ## Add custom init containers
+  ## Add custom init begin containers - first init container to run
+  customInitContainersBegin: |
+  #  - name: "custom-begin-setup"
+  #    image: "{{ .Values.initContainer.image }}"
+  #    imagePullPolicy: "{{ .Values.initContainer.pullPolicy}}"
+  #    command:
+  #      - 'sh'
+  #      - '-c'
+  #      - 'touch {{ .Values.pipelines.mountPath }}/example-custom-setup'
+  #    volumeMounts:
+  #      - mountPath: "{{ .Values.pipelines.mountPath}}"
+  #        name: jfrog-pipelines-folder
+
+  ## Add custom init containers - last init container to run
   customInitContainers: |
   #  - name: "custom-setup"
   #    image: "{{ .Values.initContainer.image }}"
@@ -441,7 +454,7 @@ pipelines:
   #      - 'touch {{ .Values.pipelines.mountPath }}/example-custom-setup'
   #    volumeMounts:
   #      - mountPath: "{{ .Values.pipelines.mountPath}}"
-  #        name: pipelines-data
+  #        name: jfrog-pipelines-folder
 
   ## Add custom sidecar containers
   # - The provided example uses a custom volume (customVolumes)
@@ -1166,7 +1179,7 @@ vault:
   #    subPath: script.sh
 
   ## Add custom init begin containers - first init container to run
-  customInitBeginContainers: |
+  customInitContainersBegin: |
   #  - name: "custom-begin-setup"
   #    image: "{{ .Values.initContainer.image }}"
   #    imagePullPolicy: "{{ .Values.initContainer.pullPolicy}}"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Changes to use the same name customInitContainerBegin vs customInitBeginContainer per @eldada and @chukka 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
PTRENG-1120

**Special notes for your reviewer**:

Tested w/ all init containers turned on and verified:

kubectl get pods
NAME                                      READY   STATUS    RESTARTS   AGE
artifactory-ha-artifactory-ha-member-0    1/1     Running   0          49m
artifactory-ha-artifactory-ha-primary-0   1/1     Running   0          49m
artifactory-ha-nginx-544d7c9895-hf9r2     1/1     Running   0          49m
artifactory-ha-postgresql-0               1/1     Running   0          49m
pipelines-pipelines-services-0            12/12   Running   0          2m19s
pipelines-pipelines-vault-0               2/2     Running   0          2m19s
pipelines-postgresql-0                    1/1     Running   0          2m19s
pipelines-rabbitmq-0                      1/1     Running   0          2m19s
pipelines-redis-master-0                  1/1     Running   0          2m20s
