### PR TITLE
[artifactory][artifactory-ha] Artifactory chown log line issue

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [4.4.2] - Oct 22, 2020
 * Chown bug fix where Linux capability cannot chown all files causing log line warnings
+* Fix Frontend timeout linting issue
 
 ## [4.4.1] - Oct 20, 2020
 * Add flag to disable prepare-custom-persistent-volume init container

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.4.2] - Oct 22, 2020
+* Chown bug fix where Linux capability cannot chown all files causing log line warnings
+
 ## [4.4.1] - Oct 20, 2020
 * Add flag to disable prepare-custom-persistent-volume init container
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 4.4.1
+version: 4.4.2
 appVersion: 7.10.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -164,9 +164,7 @@ spec:
           - >
             chown -Rv {{ .Values.artifactory.uid }}:{{ .Values.artifactory.uid }} {{ .Values.artifactory.customPersistentPodVolumeClaim.mountPath }}
         securityContext:
-          capabilities:
-            add:
-              - CHOWN
+          runAsUser: 0
         resources:
 {{ toYaml .Values.initContainers.resources | indent 10 }}
         volumeMounts:

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -537,7 +537,7 @@ artifactory:
           extraConfig: {{ .Values.artifactory.tomcat.connector.extraConfig }}
     frontend:
       session:
-        timeMinutes: {{ .Values.frontend.session.timeoutMinutes }}
+        timeMinutes: {{ .Values.frontend.session.timeoutMinutes | quote }}
     access:
       database:
         maxOpenConnections: {{ .Values.access.database.maxOpenConnections }}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [11.4.2] - Oct 22, 2020
 * Chown bug fix where Linux capability cannot chown all files causing log line warnings
+* Fix Frontend timeout linting issue
 
 ## [11.4.1] - Oct 20, 2020
 * Add flag to disable prepare-custom-persistent-volume init container

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [11.4.2] - Oct 22, 2020
+* Chown bug fix where Linux capability cannot chown all files causing log line warnings
+
 ## [11.4.1] - Oct 20, 2020
 * Add flag to disable prepare-custom-persistent-volume init container
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 11.4.1
+version: 11.4.2
 appVersion: 7.10.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -207,9 +207,7 @@ spec:
             echo "Setting ownership {{ .Values.artifactory.uid }}:{{ .Values.artifactory.uid }} on PVC {{ .Values.artifactory.customPersistentPodVolumeClaim.name }}"
             chown -Rv {{ .Values.artifactory.uid }}:{{ .Values.artifactory.uid }} {{ .Values.artifactory.customPersistentPodVolumeClaim.mountPath }}
         securityContext:
-          capabilities:
-            add:
-              - CHOWN
+          runAsUser: 0
         volumeMounts:
           - name: {{ .Values.artifactory.customPersistentPodVolumeClaim.name }}
             mountPath: {{ .Values.artifactory.customPersistentPodVolumeClaim.mountPath }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -470,7 +470,7 @@ artifactory:
           extraConfig: {{ .Values.artifactory.tomcat.connector.extraConfig }}
     frontend:
       session:
-        timeMinutes: {{ .Values.frontend.session.timeoutMinutes }}
+        timeMinutes: {{ .Values.frontend.session.timeoutMinutes | quote }}
     access:
       database:
         maxOpenConnections: {{ .Values.access.database.maxOpenConnections }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
During JFrog Support session w/ customer we had log line warnings about issues with chown:

2)

2020-10-20T20:31:29.468838574Z chown: /opt/jfrog/artifactory: Operation not permitted

2020-10-20T20:31:29.486238263Z 2020-10-20T20:31:29.000Z [shell] [WARN ] [] [installerCommon.sh:706        ] [main] - Could not set owner of [/opt/jfrog/artifactory] to [artifactory:artifactory]

2020-10-20T20:31:29.540815982Z chown: /opt/jfrog/artifactory/var: Operation not permitted

2020-10-20T20:31:29.557993665Z 2020-10-20T20:31:29.000Z [shell] [WARN ] [] [installerCommon.sh:706        ] [main] - Could not set owner of [/opt/jfrog/artifactory/var] to [artifactory:artifactory]

 
Further research into this appears that /opt/jfrog/artifactory is not a mount point which Linux capabilities in Docker containers can only apply CAP_CHOWN to mount points. /opt/jfrog/artifactory/var is a soft link which is also a problem for CAP_CHOWN.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Customer support request to resolve. Openshift has to apply anyuid scc patch so no impact for now.

**Special notes for your reviewer**:

This reverts the CAP_CHOWN from the helm charts because we are trying to use it in a container when they only support this on volumes / mount points. To clean up the log lines (Artifactory starts both ways) we should revert the CAP_CHOWN for now until we can address it with core product team.