### PR TITLE
Update port names to include protocols

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.5.0] - Oct 30, 2020
+* Updated port namings on services and pods to allow for istio protocol discovery
+
 ## [4.4.2] - Oct 22, 2020
 * Chown bug fix where Linux capability cannot chown all files causing log line warnings
 * Fix Frontend timeout linting issue

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 4.4.2
+version: 4.5.0
 appVersion: 7.10.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -391,9 +391,9 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ .Values.artifactory.internalPort }}
-          name: http-internal
+          name: http
         - containerPort: {{ .Values.artifactory.internalArtifactoryPort }}
-          name: http-internalArtifactory
+          name: http-internal
         {{- if .Values.artifactory.node.javaOpts.jmx.enabled }}
         - containerPort: {{ .Values.artifactory.node.javaOpts.jmx.port }}
           name: tcp-jmx

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -391,12 +391,16 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ .Values.artifactory.internalPort }}
+          name: http-internal
         - containerPort: {{ .Values.artifactory.internalArtifactoryPort }}
+          name: http-internalArtifactory
         {{- if .Values.artifactory.node.javaOpts.jmx.enabled }}
         - containerPort: {{ .Values.artifactory.node.javaOpts.jmx.port }}
+          name: tcp-jmx
         {{- end }}
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.artifactory.ssh.internalPort }}
+          name: tcp-ssh
         {{- end }}
         volumeMounts:
        {{- if .Values.artifactory.customPersistentVolumeClaim }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -487,9 +487,9 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ .Values.artifactory.internalPort }}
-          name: http-internal
+          name: http
         - containerPort: {{ .Values.artifactory.internalArtifactoryPort }}
-          name: http-internalArtifactory
+          name: http-internal
         {{- if .Values.artifactory.primary.javaOpts.jmx.enabled }}
         - containerPort: {{ .Values.artifactory.primary.javaOpts.jmx.port }}
           name: tcp-jmx

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -487,12 +487,16 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ .Values.artifactory.internalPort }}
+          name: http-internal
         - containerPort: {{ .Values.artifactory.internalArtifactoryPort }}
+          name: http-internalArtifactory
         {{- if .Values.artifactory.primary.javaOpts.jmx.enabled }}
         - containerPort: {{ .Values.artifactory.primary.javaOpts.jmx.port }}
+          name: tcp-jmx
         {{- end }}
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.artifactory.ssh.internalPort }}
+          name: tcp-ssh
         {{- end }}
         volumeMounts:
         {{- if .Values.artifactory.customPersistentVolumeClaim }}

--- a/stable/artifactory-ha/templates/artifactory-service.yaml
+++ b/stable/artifactory-ha/templates/artifactory-service.yaml
@@ -29,23 +29,23 @@ spec:
   - port: {{ .Values.artifactory.externalPort }}
     targetPort: {{ .Values.artifactory.internalPort }}
     protocol: TCP
-    name: router
+    name: http-router
   {{- if .Values.artifactory.ssh.enabled }}
   - port: {{ .Values.artifactory.ssh.externalPort }}
     targetPort: {{ .Values.artifactory.ssh.internalPort }}
     protocol: TCP
-    name: ssh
+    name: tcp-ssh
   {{- end }}
   - port: {{ .Values.artifactory.externalArtifactoryPort }}
     targetPort: {{ .Values.artifactory.internalArtifactoryPort }}
     protocol: TCP
-    name: artifactory
+    name: http-artifactory
   {{- with .Values.artifactory.node.javaOpts.jmx }}
   {{- if .enabled }}
   - port: {{ .port }}
     targetPort: {{ .port }}
     protocol: TCP
-    name: jmx
+    name: tcp-jmx
   {{- end }}
   {{- end }}
   selector:
@@ -83,23 +83,23 @@ spec:
   - port: {{ .Values.artifactory.externalPort }}
     targetPort: {{ .Values.artifactory.internalPort }}
     protocol: TCP
-    name: router
+    name: http-router
   - port: {{ .Values.artifactory.externalArtifactoryPort }}
     targetPort: {{ .Values.artifactory.internalArtifactoryPort }}
     protocol: TCP
-    name: artifactory
+    name: http-artifactory
   {{- if .Values.artifactory.ssh.enabled }}
   - port: {{ .Values.artifactory.ssh.externalPort }}
     targetPort: {{ .Values.artifactory.ssh.internalPort }}
     protocol: TCP
-    name: ssh
+    name: tcp-ssh
   {{- end }}
   {{- with .Values.artifactory.primary.javaOpts.jmx }}
   {{- if .enabled }}
   - port: {{ .port }}
     targetPort: {{ .port }}
     protocol: TCP
-    name: jmx
+    name: tcp-jmx
   {{- end }}
   {{- end }}
   selector:

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -72,19 +72,24 @@ spec:
         {{- if .Values.nginx.http }}
         {{- if .Values.nginx.http.enabled }}
         - containerPort: {{ .Values.nginx.http.internalPort }}
+          name: http-internal
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttp }}
+          name: http-internalHttp
         {{- end }}
         {{- if .Values.nginx.https }}
         {{- if .Values.nginx.https.enabled }}
         - containerPort: {{ .Values.nginx.https.internalPort }}
+          name: https-internal
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttps }}
+          name: https-internalHttps
         {{- end }}
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.nginx.ssh.internalPort }}
+          name: tcp-ssh
         {{- end }}
         volumeMounts:
         - name: nginx-conf

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -72,20 +72,20 @@ spec:
         {{- if .Values.nginx.http }}
         {{- if .Values.nginx.http.enabled }}
         - containerPort: {{ .Values.nginx.http.internalPort }}
-          name: http-internal
+          name: http
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttp }}
-          name: http-internalHttp
+          name: http-internal
         {{- end }}
         {{- if .Values.nginx.https }}
         {{- if .Values.nginx.https.enabled }}
         - containerPort: {{ .Values.nginx.https.internalPort }}
-          name: https-internal
+          name: https
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttps }}
-          name: https-internalHttps
+          name: https-internal
         {{- end }}
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.nginx.ssh.internalPort }}

--- a/stable/artifactory-ha/templates/nginx-service.yaml
+++ b/stable/artifactory-ha/templates/nginx-service.yaml
@@ -70,7 +70,7 @@ spec:
   - port: {{ .Values.nginx.ssh.externalPort }}
     targetPort: {{ .Values.nginx.ssh.internalPort }}
     protocol: TCP
-    name: ssh
+    name: tcp-ssh
   {{- end }}
   selector:
     app: {{ template "artifactory-ha.name" . }}

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [11.5.0] - Oct 30, 2020
+* Updated port namings on services and pods to allow for istio protocol discovery
+
 ## [11.4.2] - Oct 22, 2020
 * Chown bug fix where Linux capability cannot chown all files causing log line warnings
 * Fix Frontend timeout linting issue

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 11.4.2
+version: 11.5.0
 appVersion: 7.10.2
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-service.yaml
+++ b/stable/artifactory/templates/artifactory-service.yaml
@@ -25,23 +25,23 @@ spec:
   - port: {{ .Values.artifactory.externalPort }}
     targetPort: {{ .Values.artifactory.internalPort }}
     protocol: TCP
-    name: router
+    name: http-router
   - port: {{ .Values.artifactory.externalArtifactoryPort }}
     targetPort: {{ .Values.artifactory.internalArtifactoryPort }}
     protocol: TCP
-    name: artifactory
+    name: http-artifactory
   {{- if .Values.artifactory.ssh.enabled }}
   - port: {{ .Values.artifactory.ssh.externalPort }}
     targetPort: {{ .Values.artifactory.ssh.internalPort }}
     protocol: TCP
-    name: ssh
+    name: tcp-ssh
   {{- end }}
   {{- with .Values.artifactory.javaOpts.jmx }}
   {{- if .enabled }}
   - port: {{ .port }}
     targetPort: {{ .port }}
     protocol: TCP
-    name: jmx
+    name: tcp-jmx
   {{- end }}
   {{- end }}
   selector:

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -419,9 +419,9 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ .Values.artifactory.internalPort }}
-          name: http-internal
+          name: http
         - containerPort: {{ .Values.artifactory.internalArtifactoryPort }}
-          name: http-internalArtifactory
+          name: http-internal
         {{- if .Values.artifactory.javaOpts.jmx.enabled }}
         - containerPort: {{ .Values.artifactory.javaOpts.jmx.port }}
           name: tcp-jmx

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -419,12 +419,16 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ .Values.artifactory.internalPort }}
+          name: http-internal
         - containerPort: {{ .Values.artifactory.internalArtifactoryPort }}
+          name: http-internalArtifactory
         {{- if .Values.artifactory.javaOpts.jmx.enabled }}
         - containerPort: {{ .Values.artifactory.javaOpts.jmx.port }}
+          name: tcp-jmx
         {{- end }}
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.artifactory.ssh.internalPort }}
+          name: tcp-ssh
         {{- end }}
         volumeMounts:
       {{- if .Values.artifactory.userPluginSecrets }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -75,20 +75,20 @@ spec:
         {{- if .Values.nginx.http }}
         {{- if .Values.nginx.http.enabled }}
         - containerPort: {{ .Values.nginx.http.internalPort }}
-          name: http-internal
+          name: http
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttp }}
-          name: http-internalHttp
+          name: http-internal
         {{- end }}
         {{- if .Values.nginx.https }}
         {{- if .Values.nginx.https.enabled }}
         - containerPort: {{ .Values.nginx.https.internalPort }}
-          name: https-internal
+          name: https
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttps }}
-          name: https-internalHttps
+          name: https-internal
         {{- end }}
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.nginx.ssh.internalPort }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -75,19 +75,24 @@ spec:
         {{- if .Values.nginx.http }}
         {{- if .Values.nginx.http.enabled }}
         - containerPort: {{ .Values.nginx.http.internalPort }}
+          name: http-internal
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttp }}
+          name: http-internalHttp
         {{- end }}
         {{- if .Values.nginx.https }}
         {{- if .Values.nginx.https.enabled }}
         - containerPort: {{ .Values.nginx.https.internalPort }}
+          name: https-internal
         {{- end }}
         {{- else }} # DEPRECATED
         - containerPort: {{ .Values.nginx.internalPortHttps }}
+          name: https-internalHttps
         {{- end }}
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.nginx.ssh.internalPort }}
+          name: tcp-ssh
         {{- end }}
         volumeMounts:
         - name: nginx-conf

--- a/stable/artifactory/templates/nginx-service.yaml
+++ b/stable/artifactory/templates/nginx-service.yaml
@@ -64,7 +64,7 @@ spec:
   - port: {{ .Values.nginx.ssh.externalPort }}
     targetPort: {{ .Values.nginx.ssh.internalPort }}
     protocol: TCP
-    name: ssh
+    name: tcp-ssh
   {{- end }}
   selector:
     app: {{ template "artifactory.name" . }}

--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.2.0] - Oct 30, 2020
+* Updated port namings on services and pods to allow for istio protocol discovery
+
 ## [5.1.1] - Oct 24, 2020
 * Update router version to `1.4.4`
 

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 home: https://jfrog.com/mission-control/
-version: 5.1.1
+version: 5.2.0
 appVersion: 4.5.0
 description: A Helm chart for JFrog Mission Control
 sources:

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -260,9 +260,9 @@ spec:
               name: {{ template "mission-control.fullname" . }}-elasticsearch-cred
               key: url
         ports:
-        - name: eshttp
+        - name: http-eshttp
           containerPort: {{ .Values.elasticsearch.httpPort }}
-        - name: estransport
+        - name: tcp-estransport
           containerPort: {{ .Values.elasticsearch.transportPort }}
         volumeMounts:
         - name: elasticsearch-data
@@ -290,7 +290,7 @@ spec:
           sleep 10;
           /opt/jfrog/router/app/bin/entrypoint-router.sh;
         ports:
-        - name: router
+        - name: http-router
           containerPort: {{ .Values.router.internalPort }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -363,6 +363,7 @@ spec:
         ports:
         - containerPort: {{ .Values.missionControl.internalPort }}
           protocol: TCP
+          name: http-missioncontrol
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -449,6 +450,7 @@ spec:
         ports:
         - containerPort: {{ .Values.insightServer.internalPort }}
           protocol: TCP
+          name: http-insightServer
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -521,6 +523,7 @@ spec:
         ports:
         - containerPort: {{ .Values.insightScheduler.internalPort }}
           protocol: TCP
+          name: http-insightScheduler
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -363,7 +363,7 @@ spec:
         ports:
         - containerPort: {{ .Values.missionControl.internalPort }}
           protocol: TCP
-          name: http-missioncontrol
+          name: http-mc
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -450,7 +450,7 @@ spec:
         ports:
         - containerPort: {{ .Values.insightServer.internalPort }}
           protocol: TCP
-          name: http-insightServer
+          name: http-inserver
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -523,7 +523,7 @@ spec:
         ports:
         - containerPort: {{ .Values.insightScheduler.internalPort }}
           protocol: TCP
-          name: http-insightScheduler
+          name: http-insched
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}

--- a/stable/mission-control/templates/mission-control-svc.yaml
+++ b/stable/mission-control/templates/mission-control-svc.yaml
@@ -25,10 +25,10 @@ spec:
 {{- if .Values.elasticsearch.enabled }}
   - name: estransport
     port: {{ .Values.elasticsearch.transportPort }}
-    targetPort: estransport
-  - name: eshttp
+    targetPort: tcp-estransport
+  - name: http-eshttp
     port: {{ .Values.elasticsearch.httpPort }}
-    targetPort: eshttp
+    targetPort: http-eshttp
 {{- end }}
   publishNotReadyAddresses: true
   selector:

--- a/stable/pipelines/CHANGELOG.md
+++ b/stable/pipelines/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Pipelines Chart Changelog
 All changes to this chart to be documented in this file
 
+## [2.1.0] October 30, 2020
+* Updated port namings on services and pods to allow for istio protocol discovery
+
 ## [2.0.4] October 26, 2020
 * Readme update for upgrading rabbitmq
 

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pipelines
 home: https://jfrog.com/pipelines/
-version: 2.0.4
+version: 2.1.0
 appVersion: 1.8.7
 description: A Helm chart for JFrog Pipelines
 sources:

--- a/stable/pipelines/templates/api-ingress.yaml
+++ b/stable/pipelines/templates/api-ingress.yaml
@@ -35,6 +35,6 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: api
+              servicePort: http-api
   {{- end }}
 {{- end }}

--- a/stable/pipelines/templates/api-service.yaml
+++ b/stable/pipelines/templates/api-service.yaml
@@ -27,7 +27,7 @@ spec:
 {{- end }}
       targetPort: 30000
       protocol: TCP
-      name: api
+      name: http-api
   selector:
     {{- include "pipelines.selectorLabels" . | nindent 4 }}
     component: {{ include "pipelines.services.name" . }}

--- a/stable/pipelines/templates/pipelines-service-headless.yaml
+++ b/stable/pipelines/templates/pipelines-service-headless.yaml
@@ -11,11 +11,11 @@ spec:
     - port: {{ .Values.pipelines.api.service.port }}
       targetPort: 30000
       protocol: TCP
-      name: api
+      name: http-api
     - port: {{ .Values.pipelines.www.service.port }}
       targetPort: 30001
       protocol: TCP
-      name: www
+      name: http-www
   selector:
     {{- include "pipelines.selectorLabels" . | nindent 4 }}
     component: {{ include "pipelines.services.name" . }}

--- a/stable/pipelines/templates/pipelines-statefulset.yaml
+++ b/stable/pipelines/templates/pipelines-statefulset.yaml
@@ -210,7 +210,7 @@ spec:
             - name: JF_ROUTER_ENCRYPTSYSTEMCONFIG
               value: "true"
           ports:
-            - name: router
+            - name: http-router
               containerPort: {{ .Values.pipelines.router.internalPort }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -228,7 +228,7 @@ spec:
                 fieldRef:
                   fieldPath: "metadata.name"
           ports:
-            - name: api
+            - name: http-api
               containerPort: 30000
 
           {{- if .Values.pipelines.api.livenessProbe.enabled }}
@@ -267,7 +267,7 @@ spec:
           image: {{ include "pipelines.getImageInfoByValue" (list . "pipelines" "www" ) }}
           imagePullPolicy: {{ .Values.pipelines.www.image.pullPolicy }}
           ports:
-            - name: www
+            - name: http-www
               containerPort: 30001
           {{- if .Values.pipelines.www.livenessProbe.enabled }}
           livenessProbe:

--- a/stable/pipelines/templates/vault-service-headless.yaml
+++ b/stable/pipelines/templates/vault-service-headless.yaml
@@ -14,7 +14,7 @@ spec:
       port: {{ .Values.vault.service.port }}
       targetPort: 30100
       protocol: TCP
-    - name: server
+    - name: http-server
       port: 30101
       protocol: TCP  
   selector:

--- a/stable/pipelines/templates/vault-service.yaml
+++ b/stable/pipelines/templates/vault-service.yaml
@@ -13,7 +13,7 @@ spec:
       port: {{ .Values.vault.service.port }}
       targetPort: 30100
       protocol: TCP
-    - name: server
+    - name: http-server
       port: 30101
       protocol: TCP  
   selector:

--- a/stable/pipelines/templates/vault-statefulset.yaml
+++ b/stable/pipelines/templates/vault-statefulset.yaml
@@ -146,7 +146,7 @@ spec:
             - name: http
               containerPort: 30100
               protocol: "TCP"
-            - name: server
+            - name: http-server
               containerPort: 30101
               protocol: "TCP"
           readinessProbe:

--- a/stable/pipelines/templates/www-ingress.yaml
+++ b/stable/pipelines/templates/www-ingress.yaml
@@ -35,6 +35,6 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: www
+              servicePort: http-www
   {{- end }}
 {{- end }}

--- a/stable/pipelines/templates/www-service.yaml
+++ b/stable/pipelines/templates/www-service.yaml
@@ -27,7 +27,7 @@ spec:
 {{- end }}
       targetPort: 30001
       protocol: TCP
-      name: www
+      name: http-www
   selector:
     {{- include "pipelines.selectorLabels" . | nindent 4 }}
     component: {{ include "pipelines.services.name" . }}

--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [6.3.0] - Oct 30, 2020
+* Updated port namings on services and pods to allow for istio protocol discovery
+
 ## [6.2.1] - Oct 23, 2020
 * Update router version to `1.4.4`
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xray
 home: https://www.jfrog.com/xray/
-version: 6.2.1
+version: 6.3.0
 appVersion: 3.10.3
 description: Universal component scan for security and license inventory and impact
   analysis

--- a/stable/xray/templates/xray-statefulset.yaml
+++ b/stable/xray/templates/xray-statefulset.yaml
@@ -143,7 +143,7 @@ spec:
           {{- end }}
             /opt/jfrog/router/app/bin/entrypoint-router.sh;
         ports:
-          - name: router
+          - name: http-router
             containerPort: {{ .Values.router.internalPort }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -235,6 +235,7 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.server.internalPort }}
+          name: http-server
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.xray.persistence.mountPath }}"
@@ -331,6 +332,7 @@ spec:
           value: "true"
         ports:
         - containerPort: {{ .Values.analysis.internalPort }}
+          name: http-analysis
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.xray.persistence.mountPath }}"
@@ -427,6 +429,7 @@ spec:
           value: "true"
         ports:
         - containerPort: {{ .Values.indexer.internalPort }}
+          name: http-indexer
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.xray.persistence.mountPath }}"
@@ -519,6 +522,7 @@ spec:
           value: "true"
         ports:
         - containerPort: {{ .Values.persist.internalPort }}
+          name: http-persist
         volumeMounts:
         - name: data-volume
           mountPath: "{{ .Values.xray.persistence.mountPath }}"

--- a/stable/xray/templates/xray-svc.yaml
+++ b/stable/xray/templates/xray-svc.yaml
@@ -23,7 +23,7 @@ spec:
     targetPort: {{ .Values.server.internalPort }}
   - port: {{ .Values.router.externalPort }}
     protocol: TCP
-    name: router
+    name: http-router
     targetPort: {{ .Values.router.internalPort }}
   selector:
     app: {{ template "xray.name" . }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR updates all the port names to include a protocol prefix. This is important for installations that would like to use istio as it relies on these prefixes to determine the protocol of the port. (See [here](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/))

I have updated every port that I could find that didn't already have a port name that included the protocol.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

There's a 15 character limit on port names, so I had to chomp some of them down. If you disagree with what I've chosen please let me know, it was fairly arbitrary.

I was unsure whether this would be considered a patch or feature bump for each chart. Happy to update the PR to change the versions.

I have performed a helm install with the `artifactory-ha`, `artifactory`, `mission-control`, `xray`, and `pipelines` charts, and confirmed that the pods at least try to start.
