### PR TITLE
[mission-control] Add protocol to port names for istio

### DIFF
--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file
 
+## [5.4.0] - Dec 3, 2020
+* Updated port namings on services and pods to allow for istio protocol discovery
+
 ## [5.3.2] - Nov 30, 2020
 * Update router version to `7.11.5`
 * Added special notes in readme for upgrading to 5.2.x and above chart versions

--- a/stable/mission-control/CHANGELOG.md
+++ b/stable/mission-control/CHANGELOG.md
@@ -1,7 +1,7 @@
 # JFrog Mission-Control Chart Changelog
 All changes to this chart will be documented in this file
 
-## [5.4.0] - Dec 3, 2020
+## [5.3.3] - Dec 3, 2020
 * Updated port namings on services and pods to allow for istio protocol discovery
 
 ## [5.3.2] - Nov 30, 2020

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 home: https://jfrog.com/mission-control/
-version: 5.3.2
+version: 5.4.0
 appVersion: 4.6.1
 description: A Helm chart for JFrog Mission Control
 sources:

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mission-control
 home: https://jfrog.com/mission-control/
-version: 5.4.0
+version: 5.3.3
 appVersion: 4.6.1
 description: A Helm chart for JFrog Mission Control
 sources:

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -286,8 +286,6 @@ spec:
               name: {{ template "mission-control.fullname" . }}-elasticsearch-cred
               key: url
         ports:
-        - name: http-estransprt
-          containerPort: {{ .Values.elasticsearch.httpPort }}
         - name: tcp-estransprt
           containerPort: {{ .Values.elasticsearch.transportPort }}
         volumeMounts:

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -286,7 +286,9 @@ spec:
               name: {{ template "mission-control.fullname" . }}-elasticsearch-cred
               key: url
         ports:
-        - name: estransport
+        - name: http-estransprt
+          containerPort: {{ .Values.elasticsearch.httpPort }}
+        - name: tcp-estransprt
           containerPort: {{ .Values.elasticsearch.transportPort }}
         volumeMounts:
         - name: elasticsearch-data
@@ -312,7 +314,7 @@ spec:
           sleep 10;
           /opt/jfrog/router/app/bin/entrypoint-router.sh;
         ports:
-        - name: router
+        - name: http-router
           containerPort: {{ .Values.router.internalPort }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -385,6 +387,7 @@ spec:
         ports:
         - containerPort: {{ .Values.missionControl.internalPort }}
           protocol: TCP
+          name: http-mc
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -471,6 +474,7 @@ spec:
         ports:
         - containerPort: {{ .Values.insightServer.internalPort }}
           protocol: TCP
+          name: http-inserver
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -543,6 +547,7 @@ spec:
         ports:
         - containerPort: {{ .Values.insightScheduler.internalPort }}
           protocol: TCP
+          name: http-insched
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}

--- a/stable/mission-control/templates/mission-control-svc.yaml
+++ b/stable/mission-control/templates/mission-control-svc.yaml
@@ -22,12 +22,12 @@ spec:
     port: {{ .Values.missionControl.externalPort }}
     targetPort: {{ .Values.missionControl.internalPort }}
     protocol: TCP
-  - name: router
+  - name: http-router
     port: {{ .Values.router.externalPort }}
     targetPort: {{ .Values.router.internalPort }}
     protocol: TCP    
 {{- if .Values.elasticsearch.enabled }}
-  - name: estransport
+  - name: tcp-estransport
     port: {{ .Values.elasticsearch.transportPort }}
     targetPort: {{ .Values.elasticsearch.transportPort }}
 {{- end }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR updates all the port names to include a protocol prefix. This is important for installations that would like to use istio as it relies on these prefixes to determine the protocol of the port. (See [here](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/))

I have updated every port that I could find that didn't already have a port name that included the protocol.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

There's a 15 character limit on port names, so I had to chomp some of them down. If you disagree with what I've chosen please let me know, it was fairly arbitrary.

I was unsure whether this would be considered a patch or feature bump for each chart. Happy to update the PR to change the versions.

I have performed a helm install with the modified chart and confirmed that the pods at least try to start.