### PR TITLE
[artifactory-ha] stateful set spec.serviceName should match the service created

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file
 
+## [4.7.5] - Jan 05, 2020
+* Aligned service name with node statefulset spec.serviceName
+
 ## [4.7.4] - Jan 04, 2020
 * Fixed gid support for statefulset
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 4.7.4
+version: 4.7.5
 appVersion: 7.12.5
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-service.yaml
+++ b/stable/artifactory-ha/templates/artifactory-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "artifactory-ha.fullname" . }}
+  name: {{ template "artifactory-ha.node.name" . }}
   labels:
     app: {{ template "artifactory-ha.name" . }}
     chart: {{ template "artifactory-ha.chart" . }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:
currently the service generated from artifactory service creates a service with name: `artifactory-ha.fullname`.  the artifactory-node-statefulset.yaml creates a spec.serviceName as `artifactory-ha.node.name`.  the service specified in the statefulset needs to align, particularly when addressing pods directly in kubernetes DNS : https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

this pr changes the service creation to have the same name as specified in the node statefulset spec.serviceName

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
none

**Special notes for your reviewer**:

@eldada @rimusz @danielezer 