### PR TITLE
[mission-control] Allow specifying uid for containers, custom annotations

### DIFF
--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -386,6 +386,26 @@ common:
       readOnly: true
 ```
 
+### Configure runAsUser explicitly
+The images used by the `mission-control`, `insight-scheduler`, `insight-server`, and `elasticsearch` containers all have named users.
+If your cluster applies a `MustRunAsNonRoot` pod security policy, you must specify the `uid`s as below.
+Reference the [kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups) for further explanation.
+
+```yaml
+missionControl:
+  image:
+    uid: 1050
+insightScheduler:
+  image:
+    uid: 1050
+insightServer:
+  image:
+    uid: 1050
+elasticsearch:
+  image:
+    uid: 1000
+```
+
 ## Useful links
 - https://www.jfrog.com/confluence/display/JFROG/JFrog+Mission+Control
 - https://www.jfrog.com/confluence/

--- a/stable/mission-control/templates/mission-control-statefulset.yaml
+++ b/stable/mission-control/templates/mission-control-statefulset.yaml
@@ -39,6 +39,9 @@ spec:
       annotations:
         checksum/database-secrets: {{ include (print $.Template.BasePath "/database-secrets.yaml") . | sha256sum }}
         checksum/systemyaml: {{ include (print $.Template.BasePath "/mission-control-system-yaml.yaml") . | sha256sum }}
+      {{- range $key, $value := .Values.missionControl.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "mission-control.serviceAccountName" . }}
     {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
@@ -304,6 +307,10 @@ spec:
         ports:
         - name: tcp-estransprt
           containerPort: {{ .Values.elasticsearch.transportPort }}
+        {{- if .Values.elasticsearch.image.uid }}
+        securityContext:
+          runAsUser: {{ .Values.elasticsearch.image.uid }}
+        {{- end }}
         volumeMounts:
         - name: elasticsearch-data
           mountPath: {{ .Values.elasticsearch.persistence.mountPath | quote }}
@@ -410,6 +417,10 @@ spec:
         - containerPort: {{ .Values.missionControl.internalPort }}
           protocol: TCP
           name: http-mc
+        {{- if .Values.missionControl.image.uid }}
+        securityContext:
+          runAsUser: {{ .Values.missionControl.image.uid }}
+        {{- end }}
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -501,6 +512,10 @@ spec:
         - containerPort: {{ .Values.insightServer.internalPort }}
           protocol: TCP
           name: http-inserver
+        {{- if .Values.insightServer.image.uid }}
+        securityContext:
+          runAsUser: {{ .Values.insightServer.image.uid }}
+        {{- end }}
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}
@@ -578,6 +593,10 @@ spec:
         - containerPort: {{ .Values.insightScheduler.internalPort }}
           protocol: TCP
           name: http-insched
+        {{- if .Values.insightScheduler.image.uid }}
+        securityContext:
+          runAsUser: {{ .Values.insightScheduler.image.uid }}
+        {{- end }}
         volumeMounts:
         - name: mission-control-data
           mountPath: {{ .Values.missionControl.persistence.mountPath | quote }}

--- a/stable/mission-control/values.yaml
+++ b/stable/mission-control/values.yaml
@@ -305,6 +305,7 @@ elasticsearch:
     repository: jfrog/elasticsearch-oss-sg
     tag: 7.10.2
     pullPolicy: IfNotPresent
+    uid:
   ## Enter elasticsearch connection details
   ## By default url is set to localhost:8082 (router)
   ## If external elasticsearch is used, provide external elasticsearch url and set elasticsearch.enabled=false
@@ -401,10 +402,12 @@ missionControl:
     registry: releases-docker.jfrog.io
     repository: jfrog/mission-control
     # tag:
+    uid:
   appContext: mc
   appName: jfmc-server
   home: /var/opt/jfrog/mc
   labels: {}
+  annotations: {}
 
   # env:
 
@@ -632,6 +635,7 @@ insightServer:
     registry: releases-docker.jfrog.io
     repository: jfrog/insight-server
     # tag:
+    uid:
   appContext: insight
   home: /opt/jfrog
   internalPort: 8087
@@ -731,6 +735,7 @@ insightScheduler:
     registry: releases-docker.jfrog.io
     repository: jfrog/insight-scheduler
     # tag:
+    uid:
   appContext: insight-scheduler
   home: /opt/jfrog
   internalPort: 8085


### PR DESCRIPTION
I am unsure how to bump chart version, or edit changelog. Could you provide me with guidelines?

About the change: Our cluster applies the `MustRunAsNonRoot` pod security policy, which does not allow containers with named users to spin up without specifying `runAsUser` with a numeric uid.
The mission control, insight scheduler, insight server & elasticsearch images used by this chart all have named users (`jfmc` and `elasticsearch` to be exact). Kubernetes would refuse to start them up with the error message "CreateContainerConfigError: container has runAsNonRoot and image has non-numeric user (elasticsearch), cannot verify user is non-root"

This change allows you to specify the numeric uid to avoid this issue.
I've also copied the custom annotations implementation from artifactory-ha.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

