### PR TITLE
[artifactory] Add resources to migration-artifactory init container

### DIFF
--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -277,6 +277,8 @@ spec:
 {{- if .Values.artifactory.migration.enabled }}
       - name: 'migration-artifactory'
         image: {{ include "artifactory.getImageInfoByValue" (list . "artifactory") }}
+        resources:
+{{ toYaml .Values.initContainers.resources | indent 10 }}
         imagePullPolicy: {{ .Values.artifactory.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

On our kubernetes cluster, all containers must have resources specified.

There is currently no way to specify resources on the "migration-artifactory" one.

**Special notes for your reviewer**:

I added the same value as for other init containers. Maybe the limits should be greater for this container?
I only tested on an installation from scratch (no migration necessary).

It's a small change. I don't know if I should bump the version and update the changelog.