### PR TITLE
[artifactory, artifactory-ha] Add topologySpreadConstraints to artifactory and nginx, and add lifecycle hooks to nginx

### DIFF
--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -63,6 +63,17 @@ spec:
         fsGroupChangePolicy: {{ .Values.artifactory.fsGroupChangePolicy }}
         {{- end }}
       {{- end }}
+      {{- with .Values.artifactory.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "artifactory-ha.name" $ }}
+            component: {{ $.Values.artifactory.name }}
+            release: {{ $.Release.Name }}
+      {{- end }}
       initContainers:
     {{- if or .Values.artifactory.customInitContainersBegin .Values.global.customInitContainersBegin }}
 {{ tpl (include "artifactory-ha.customInitContainersBegin" .)  . | indent 6 }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -73,6 +73,17 @@ spec:
         fsGroupChangePolicy: {{ .Values.artifactory.fsGroupChangePolicy }}
         {{- end }}
       {{- end }}
+      {{- with .Values.artifactory.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "artifactory-ha.name" $ }}
+            component: {{ $.Values.artifactory.name }}
+            release: {{ $.Release.Name }}
+      {{- end }}
       initContainers:
     {{- if or .Values.artifactory.customInitContainersBegin .Values.global.customInitContainersBegin }}
 {{ tpl (include "artifactory-ha.customInitContainersBegin" .)  . | indent 6 }}

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -42,6 +42,17 @@ spec:
       {{- if .Values.nginx.priorityClassName }}
       priorityClassName: {{ .Values.nginx.priorityClassName | quote }}
       {{- end }}
+      {{- with .Values.nginx.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "artifactory-ha.name" $ }}
+            release: {{ $.Release.Name }}
+            component: {{ $.Values.nginx.name }}
+      {{- end }}
       initContainers:
         {{- if .Values.nginx.customInitContainers }}
 {{ tpl (include "artifactory.nginx.customInitContainers" .)  . | indent 6 }}
@@ -97,6 +108,10 @@ spec:
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.nginx.ssh.internalPort }}
           name: tcp-ssh
+        {{- end }}
+        {{- with .Values.nginx.lifecycle }}
+        lifecycle:
+{{ toYaml . | indent 10 }}
         {{- end }}
         volumeMounts:
         - name: nginx-conf

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -1366,6 +1366,13 @@ artifactory:
 
   annotations: {}
 
+  # Spread Artifactory pods evenly across your nodes or some other topology
+  # Note this applies to both the primary and replicas
+  topologySpreadConstraints: {}
+    # maxSkew: 1
+    # topologyKey: kubernetes.io/hostname
+    # whenUnsatisfiable: DoNotSchedule
+
   ## Type specific configurations.
   ## There is a difference between the primary and the member nodes.
   ## Customising their resources and java parameters is done here.
@@ -1786,6 +1793,16 @@ nginx:
 
   # Priority Class name to be used in deployment if provided
   priorityClassName:
+
+  # Spread nginx pods evenly across your nodes or some other topology
+  topologySpreadConstraints: {}
+    # maxSkew: 1
+    # topologyKey: kubernetes.io/hostname
+    # whenUnsatisfiable: DoNotSchedule
+
+  # Add lifecycle hooks for the nginx pods
+  # For example, you can add a `preStop` hook that sends a SIGQUIT to nginx and wait for it to terminate gracefully
+  lifecycle: {}
 
   # Sidecar containers for tailing Nginx logs
   loggers: []

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -75,6 +75,17 @@ spec:
         fsGroupChangePolicy: {{ .Values.artifactory.fsGroupChangePolicy }}
         {{- end }}
       {{- end }}
+      {{- with .Values.artifactory.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "artifactory.name" $ }}
+            role: {{ template "artifactory.name" $ }}
+            release: {{ $.Release.Name }}
+      {{- end }}
       initContainers:
     {{- if or .Values.artifactory.customInitContainersBegin .Values.global.customInitContainersBegin }}
 {{ tpl (include "artifactory.customInitContainersBegin" .)  . | indent 6 }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -45,6 +45,17 @@ spec:
       {{- if .Values.nginx.priorityClassName }}
       priorityClassName: {{ .Values.nginx.priorityClassName | quote }}
       {{- end }}
+      {{- with .Values.nginx.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "artifactory.name" $ }}
+            release: {{ $.Release.Name }}
+            component: {{ $.Values.nginx.name }}
+      {{- end }}
       initContainers:
         {{- if .Values.nginx.customInitContainers }}
 {{ tpl (include "artifactory.nginx.customInitContainers" .)  . | indent 6 }}
@@ -100,6 +111,10 @@ spec:
         {{- if .Values.artifactory.ssh.enabled }}
         - containerPort: {{ .Values.nginx.ssh.internalPort }}
           name: tcp-ssh
+        {{- end }}
+        {{- with .Values.nginx.lifecycle }}
+        lifecycle:
+{{ toYaml . | indent 10 }}
         {{- end }}
         volumeMounts:
         - name: nginx-conf

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -283,6 +283,13 @@ artifactory:
     ## Use an existing priority class
     # existingPriorityClass:
 
+  # Spread Artifactory pods evenly across your nodes or some other topology
+  # Note this applies to both the primary and replicas
+  topologySpreadConstraints: {}
+    # maxSkew: 1
+    # topologyKey: kubernetes.io/hostname
+    # whenUnsatisfiable: DoNotSchedule
+
   # Delete the db.properties file in ARTIFACTORY_HOME/etc/db.properties
   deleteDBPropertiesOnStartup: true
 
@@ -1474,6 +1481,16 @@ nginx:
 
   # Priority Class name to be used in deployment if provided
   priorityClassName:
+
+  # Spread nginx pods evenly across your nodes or some other topology
+  topologySpreadConstraints: {}
+    # maxSkew: 1
+    # topologyKey: kubernetes.io/hostname
+    # whenUnsatisfiable: DoNotSchedule
+
+  # Add lifecycle hooks for the nginx pods
+  # For example, you can add a `preStop` hook that sends a SIGQUIT to nginx and wait for it to terminate gracefully
+  lifecycle: {}
 
   # Sidecar containers for tailing Nginx logs
   loggers: []


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add `topologySpreadConstraints` to Artifactory and nginx pods, so those who wish to spread those pods across their nodes / other topology without having too many pods pegging a single node can do so. Also added a `lifecycle` option to nginx pods, so those who want to run e.g. a `preStop` hook when nginx is terminated can do so.

**Which issue this PR fixes**: closes #1593, closes #1594


**Special notes for your reviewer**:
I have not updated the changelogs since I don't know how the version numbers should be changed (since the helm version number is tied to an Artifactory version). Should I wait until the next bump in the Artifactory version? Also, I'm not sure if the `topologySpreadConstraints` is a bit too opinionated (I imagine almost everyone using it would like to spread the primary and member pods equally, but maybe someone would like to spread them separately?).

I ran a simple `helm template` both without custom values and with the following `values.yaml` to make sure the chart renders properly in both cases (and do not have additional fields if the user didn't specify the added options):
```yaml
artifactory:
  topologySpreadConstraints:
    maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
nginx:
  topologySpreadConstraints:
    maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
  lifecycle:
    preStop:
      exec:
        command:
        - "/bin/sh"
        - "-c"
        - "sleep 5; nginx -s quit; while pgrep nginx; do sleep 1; done"
```