### PR TITLE
[artifactory] Support custom MDS DB details

### DIFF
--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -676,6 +676,13 @@ artifactory:
     metadata:
       database:
         maxOpenConnections: {{ .Values.metadata.database.maxOpenConnections }}
+        {{- if .Values.metadata.database.url }}
+        type: {{ .Values.metadata.database.type }}
+        url: {{ .Values.metadata.database.url }}
+        driver: {{ .Values.metadata.database.driver }}
+        username: {{ .Values.metadata.database.username }}
+        password: {{ .Values.metadata.database.password }}
+        {{- end }}
     {{- if .Values.jfconnect.enabled }}
     jfconnect:
       enabled: true
@@ -1247,8 +1254,16 @@ access:
 metadata:
   name: metadata
   internalPort: 8086
-  database:
+  database: 
     maxOpenConnections: 80
+    # The Metadata database connection details only need to be manually configured if using external PostgreSQL HA
+    # Reference: https://www.jfrog.com/confluence/display/JFROG/PostgreSQL#PostgreSQL-ConfiguringArtifactoryHAtoUsePostgreSQLDatabaseinHA
+    # type: postgresql
+    # driver: org.postgresql.Driver
+    # username: 
+    # password: 
+    # url:
+
   resources: {}
   #  requests:
   #    memory: "100Mi"


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for custom metadata.database connection details, which is required when configuring [PostgreSQL HA](https://www.jfrog.com/confluence/display/JFROG/PostgreSQL#PostgreSQL-ConfiguringArtifactoryHAtoUsePostgreSQLDatabaseinHA)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Needing to manually edit **systemYaml: |** if a custom MDS DB details are required 
