### PR TITLE
[Xray] Set executionserviceAWS key in values.yaml like joinkey and masterkey

### DIFF
--- a/stable/xray/templates/_helpers.tpl
+++ b/stable/xray/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Create rabbitmq URL 
+Create rabbitmq URL
 */}}
 {{- define "rabbitmq.url" -}}
 {{- if index .Values "rabbitmq" "enabled" -}}
@@ -155,12 +155,12 @@ Create rabbitmq URL
 
 
 {{/*
-Create rabbitmq username 
+Create rabbitmq username
 */}}
 {{- define "rabbitmq.user" -}}
 {{- if index .Values "rabbitmq" "enabled" -}}
 {{- .Values.rabbitmq.auth.username -}}
-{{- end -}} 
+{{- end -}}
 {{- end -}}
 
 
@@ -171,7 +171,7 @@ Create rabbitmq password secret name
 {{- if index .Values "rabbitmq" "enabled" -}}
 {{- $name := default (printf "%s" "rabbitmq") .Values.rabbitmq.nameOverride -}}
 {{- .Values.rabbitmq.auth.existingPasswordSecret | default (printf "%s-%s" .Release.Name $name) -}}
-{{- end -}} 
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -215,6 +215,17 @@ Resolve masterKey value
 {{- .Values.global.masterKey -}}
 {{- else if .Values.xray.masterKey -}}
 {{- .Values.xray.masterKey -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve executionServiceAesKey value
+*/}}
+{{- define "xray.executionServiceAesKey" -}}
+{{- if .Values.global.executionServiceAesKey -}}
+{{- .Values.global.executionServiceAesKey -}}
+{{- else if .Values.xray.executionServiceAesKey -}}
+{{- .Values.xray.executionServiceAesKey -}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/xray/templates/xray-secrets.yaml
+++ b/stable/xray/templates/xray-secrets.yaml
@@ -24,4 +24,9 @@ data:
   join-key: {{ include "xray.joinKey" . | b64enc | quote }}
   {{- end }}
   {{- end }}
-  execution-service-aes-key: "{{randAlphaNum 32 | b64enc}}"
+  {{- if not (or .Values.xray.executionServiceAesKey .Values.global.executionServiceAesKey) }}
+  {{ required "\n\n.Values.xray.executionServiceAesKey or .Values.global.executionServiceAesKey is required!\n\n" .Values.xray.executionServiceAesKey }}
+  {{- end}}
+  {{- if or .Values.xray.executionServiceAesKey .Values.global.executionServiceAesKey }}
+  execution-service-aes-key: {{ include "xray.executionServiceAesKey" . | b64enc | quote }}
+  {{- end }}

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -14,6 +14,7 @@ global:
     # router:
   # joinKey:
   # masterKey:
+  # executionServiceAesKey:
   # joinKeySecretName:
   # masterKeySecretName:
 
@@ -99,6 +100,12 @@ xray:
   joinKey: EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
   ## Alternatively, you can use a pre-existing secret with a key called join-key by specifying joinKeySecretName
   # joinKeySecretName:
+
+  ## Xray AES key used by execution server to the xray server and analysis containers. Mandatory
+  ## You can generate one with the command:
+  ## 'openssl rand -hex 32'
+  executionServiceAesKey: GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG  
+
   ## If false, all service console logs will not redirect to a common console.log
   consoleLog: false
   ## Artifactory URL . Mandatory


### PR DESCRIPTION
… instead of generating randomly

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:
Allow users to set the executionServiceAesKey instead of generating it randomly. This will fix autmatic rollout of the helm chart with tools like argoCD.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #1599 

**Special notes for your reviewer**:

