### PR TITLE
[artifactory-ha] Fix some template names

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [107.35.3] - Mar 15, 2022
+* Fixed some template names
+
 ## [107.35.2] - Mar 01, 2022
 * Updated router version to `7.32.1`
 

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -20,4 +20,4 @@ name: artifactory-ha
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 107.35.2
+version: 107.35.3

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -461,7 +461,7 @@ spec:
               name: {{ tpl .Values.database.secrets.user.name . }}
               key: {{ tpl .Values.database.secrets.user.key . }}
         {{- else if .Values.database.user }}
-              name: {{ template "artifactory.fullname" . }}-database-creds
+              name: {{ template "artifactory-ha.fullname" . }}-database-creds
               key: db-user
         {{- end }}
       {{- end }}
@@ -473,7 +473,7 @@ spec:
               name: {{ tpl .Values.database.secrets.password.name . }}
               key: {{ tpl .Values.database.secrets.password.key . }}
         {{- else if .Values.database.password }}
-              name: {{ template "artifactory.fullname" . }}-database-creds
+              name: {{ template "artifactory-ha.fullname" . }}-database-creds
               key: db-password
         {{- else if .Values.postgresql.enabled }}
               name: {{ .Release.Name }}-postgresql
@@ -488,7 +488,7 @@ spec:
               name: {{ tpl .Values.database.secrets.url.name . }}
               key: {{ tpl .Values.database.secrets.url.key . }}
         {{- else if .Values.database.url }}
-              name: {{ template "artifactory.fullname" . }}-database-creds
+              name: {{ template "artifactory-ha.fullname" . }}-database-creds
               key: db-url
         {{- end }}
       {{- end }}        

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -556,7 +556,7 @@ spec:
               name: {{ tpl .Values.database.secrets.user.name . }}
               key: {{ tpl .Values.database.secrets.user.key . }}
         {{- else if .Values.database.user }}
-              name: {{ template "artifactory.fullname" . }}-database-creds
+              name: {{ template "artifactory-ha.fullname" . }}-database-creds
               key: db-user
         {{- end }}
       {{- end }}
@@ -568,7 +568,7 @@ spec:
               name: {{ tpl .Values.database.secrets.password.name . }}
               key: {{ tpl .Values.database.secrets.password.key . }}
         {{- else if .Values.database.password }}
-              name: {{ template "artifactory.fullname" . }}-database-creds
+              name: {{ template "artifactory-ha.fullname" . }}-database-creds
               key: db-password
         {{- else if .Values.postgresql.enabled }}
               name: {{ .Release.Name }}-postgresql
@@ -583,7 +583,7 @@ spec:
               name: {{ tpl .Values.database.secrets.url.name . }}
               key: {{ tpl .Values.database.secrets.url.key . }}
         {{- else if .Values.database.url }}
-              name: {{ template "artifactory.fullname" . }}-database-creds
+              name: {{ template "artifactory-ha.fullname" . }}-database-creds
               key: db-url
         {{- end }}
       {{- end }}


### PR DESCRIPTION
#### PR Checklist

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

It fixes some template names used in the `artifactory-ha` chart that are
referencing templates that are defined actually in the `artifactory` chart.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

When setting the `splitServicesToContainers` attribute in `values.yaml` to
`true`, the following error appears while running `helm template`:

> Error: template:
> artifactory-ha/templates/artifactory-primary-statefulset.yaml:559:32:
> executing "artifactory-ha/templates/artifactory-primary-statefulset.yaml"
> at <{{template "artifactory.fullname" .}}>:
> template "artifactory.fullname" not defined

The code is referencing the template `artifactory.fullname`, but the file
`stable/artifactory-ha/templates/_helpers.tpl` does not define that template,
but this one: `define "artifactory-ha.fullname"`