### PR TITLE
[artifactory, artifactory-ha] Allow disabling eventual upload mechanism

### DIFF
--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -824,6 +824,8 @@ artifactory:
     maxCacheSize: 50000000000
     cacheProviderDir: cache
     eventual:
+      # toggle this to disable the eventual upload mechanism
+      # https://www.jfrog.com/confluence/display/JFROG/S3+Object+Storage#S3ObjectStorage-Direct(Eventual-less)versusEventualUploadMechanismdirectversuseventual
       enabled: true
       numberOfThreads: 10
     ## artifactory data Persistent Volume Storage Class

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -824,6 +824,7 @@ artifactory:
     maxCacheSize: 50000000000
     cacheProviderDir: cache
     eventual:
+      enabled: true
       numberOfThreads: 10
     ## artifactory data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
@@ -930,7 +931,9 @@ artifactory:
                       <writeBehavior>crossNetworkStrategy</writeBehavior>
                       <redundancy>{{ .Values.artifactory.persistence.redundancy }}</redundancy>
                       <minSpareUploaderExecutor>2</minSpareUploaderExecutor>
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       <sub-provider id="eventual-cluster" type="eventual-cluster">
+                      {{- end }}
                           <provider id="retry" type="retry">
                               {{- if .Values.artifactory.persistence.googleStorage.gcpServiceAccount.enabled }}
                               <provider id="google-storage-v2" type="google-storage-v2"/>
@@ -938,7 +941,9 @@ artifactory:
                               <provider id="google-storage" type="google-storage"/>
                               {{- end }}
                           </provider>
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       </sub-provider>
+                      {{- end }}
                       <dynamic-provider id="remote" type="remote"/>
                       <property name="zones" value="local,remote"/>
                   </provider>
@@ -951,9 +956,11 @@ artifactory:
               <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
           </provider>
 
+          {{- if .Values.artifactory.persistence.eventual.enabled }}
           <provider id="eventual-cluster" type="eventual-cluster">
               <zone>local</zone>
           </provider>
+          {{- end }}
 
           <provider id="remote" type="remote">
               <checkPeriod>30</checkPeriod>
@@ -989,11 +996,15 @@ artifactory:
           <chain> <!--template="cluster-s3-storage-v3"-->
               <provider id="cache-fs-eventual-s3" type="cache-fs">
                   <provider id="sharding-cluster-eventual-s3" type="sharding-cluster">
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       <sub-provider id="eventual-cluster-s3" type="eventual-cluster">
+                      {{- end }}
                           <provider id="retry-s3" type="retry">
                               <provider id="s3-storage-v3" type="s3-storage-v3"/>
                           </provider>
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       </sub-provider>
+                      {{- end }}
                       <dynamic-provider id="remote-s3" type="remote"/>
                   </provider>
               </provider>
@@ -1010,9 +1021,11 @@ artifactory:
               <zone>remote</zone>
           </provider>
 
+          {{- if .Values.artifactory.persistence.eventual.enabled }}
           <provider id="eventual-cluster-s3" type="eventual-cluster">
               <zone>local</zone>
           </provider>
+          {{- end }}
 
           <!-- Set max cache-fs size -->
           <provider id="cache-fs-eventual-s3" type="cache-fs">
@@ -1078,11 +1091,15 @@ artifactory:
           <chain> <!--template="cluster-s3"-->
               <provider id="cache-fs" type="cache-fs">
                   <provider id="sharding-cluster" type="sharding-cluster">
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       <sub-provider id="eventual-cluster" type="eventual-cluster">
+                      {{- end }}
                           <provider id="retry-s3" type="retry">
                               <provider id="s3" type="s3"/>
                           </provider>
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       </sub-provider>
+                      {{- end }}
                       <dynamic-provider id="remote" type="remote"/>
                   </provider>
               </provider>
@@ -1094,9 +1111,11 @@ artifactory:
               <cacheProviderDir>{{ .Values.artifactory.persistence.cacheProviderDir }}</cacheProviderDir>
           </provider>
 
+          {{- if .Values.artifactory.persistence.eventual.enabled }}
           <provider id="eventual-cluster" type="eventual-cluster">
               <zone>local</zone>
           </provider>
+          {{- end }}
 
           <provider id="remote" type="remote">
               <checkPeriod>30</checkPeriod>
@@ -1143,11 +1162,15 @@ artifactory:
           <chain> <!--template="cluster-azure-blob-storage"-->
               <provider id="cache-fs" type="cache-fs">
                   <provider id="sharding-cluster" type="sharding-cluster">
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       <sub-provider id="eventual-cluster" type="eventual-cluster">
+                      {{- end }}
                           <provider id="retry-azure-blob-storage" type="retry">
                               <provider id="azure-blob-storage" type="azure-blob-storage"/>
                           </provider>
+                      {{- if .Values.artifactory.persistence.eventual.enabled }}
                       </sub-provider>
+                      {{- end }}
                       <dynamic-provider id="remote" type="remote"/>
                   </provider>
               </provider>
@@ -1172,9 +1195,11 @@ artifactory:
               <zone>remote</zone>
           </provider>
 
+          {{- if .Values.artifactory.persistence.eventual.enabled }}
           <provider id="eventual-cluster" type="eventual-cluster">
               <zone>local</zone>
           </provider>
+          {{- end }}
 
           <!--cluster eventual template-->
           <provider id="azure-blob-storage" type="azure-blob-storage">

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -817,6 +817,10 @@ artifactory:
     ## Cache default size. Should be increased for production deployments.
     maxCacheSize: 5000000000
     cacheProviderDir: cache
+    eventual:
+      # toggle this to disable the eventual upload mechanism
+      # https://www.jfrog.com/confluence/display/JFROG/S3+Object+Storage#S3ObjectStorage-Direct(Eventual-less)versusEventualUploadMechanismdirectversuseventual
+      enabled: true
 
     ## Set the persistence storage type. This will apply the matching binarystore.xml to Artifactory config
     ## Supported types are:
@@ -857,7 +861,9 @@ artifactory:
       <config version="2">
           <chain>
               <provider id="cache-fs" type="cache-fs">
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   <provider id="eventual" type="eventual">
+                  {{- end }}
                       <provider id="retry" type="retry">
                           {{- if .Values.artifactory.persistence.googleStorage.gcpServiceAccount.enabled }}
                           <provider id="google-storage-v2" type="google-storage-v2"/>
@@ -865,7 +871,9 @@ artifactory:
                           <provider id="google-storage" type="google-storage"/>
                           {{- end }}
                       </provider>
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   </provider>
+                  {{- end }}
               </provider>
           </chain>
 
@@ -902,11 +910,15 @@ artifactory:
       <config version="2">
           <chain>
               <provider id="cache-fs" type="cache-fs">
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   <provider id="eventual" type="eventual">
+                  {{- end }}
                       <provider id="retry" type="retry">
                           <provider id="s3-storage-v3" type="s3-storage-v3"/>
                       </provider>
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   </provider>
+                  {{- end }}
               </provider>
           </chain>
 
@@ -973,11 +985,15 @@ artifactory:
       <config version="2">
           <chain> <!--template="s3"-->
               <provider id="cache-fs" type="cache-fs">
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   <provider id="eventual" type="eventual">
+                  {{- end }}
                       <provider id="retry-s3" type="retry">
                           <provider id="s3" type="s3"/>
                       </provider>
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   </provider>
+                  {{- end }}
               </provider>
           </chain>
 
@@ -1018,11 +1034,15 @@ artifactory:
       <config version="2">
           <chain> <!--template="azure-blob-storage"-->
               <provider id="cache-fs" type="cache-fs">
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   <provider id="eventual" type="eventual">
+                  {{- end }}
                       <provider id="retry-azure-blob-storage" type="retry">
                           <provider id="azure-blob-storage" type="azure-blob-storage"/>
                       </provider>
+                  {{- if .Values.artifactory.persistence.eventual.enabled }}
                   </provider>
+                  {{- end }}
               </provider>
           </chain>
 


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [x] Variables and other changes are documented in the ~README.md~ values.yaml
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add a `artifactory.persistence.eventual.enabled` flag that's default true. The [official docs](https://www.jfrog.com/confluence/display/JFROG/S3+Object+Storage#S3ObjectStorage-Direct(Eventual-less)versusEventualUploadMechanismdirectversuseventual) says direct upload (without the eventual upload mechanism) is recommended if Artifactory is hosted on AWS. Currently `binarystore.xml` is hardcoded to always have the eventual binary provider, so this PR adds a flag to disable it if needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: None


**Special notes for your reviewer**:
I tested via a simple `helm template` with the following:
```yaml
artifactory:
  persistence:
    type: aws-s3-v3
    eventual:
      enabled: false # toggle this
```
There are some whitespace changes with `artifactory.persistence.eventual.enabled=true` compared to before the PR but I think that's fine. Let me know if that needs to be fixed.

Also, the `artifactory.persistence.eventual.numberOfThreads` option seems to be unused and I found no references to it anywhere. Should I remove it from values.yaml?