### PR TITLE
[artifactory-ha] add connectionTimeout, and socketTimeout parameters for s3-storage-v3 Binary Provider

### DIFF
--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -1024,11 +1024,17 @@ artifactory:
               <redundancy>{{ .Values.artifactory.persistence.redundancy }}</redundancy>
               <property name="zones" value="local,remote"/>
           </provider>
-
+        {{- with .Values.artifactory.persistence.remote }}
           <provider id="remote-s3" type="remote">
               <zone>remote</zone>
+            {{- with .socketTimeout }}
+              <socketTimeout>{{ . }}</socketTimeout>
+            {{- end }}  
+            {{- with .connectionTimeout }}
+              <connectionTimeout>{{ . }}</connectionTimeout>
+            {{- end }}  
           </provider>
-
+        {{- end }}
           <provider id="eventual-cluster-s3" type="eventual-cluster">
               <zone>local</zone>
           </provider>
@@ -1055,6 +1061,12 @@ artifactory:
             {{- with .maxConnections }}
               <maxConnections>{{ . }}</maxConnections>
             {{- end }}
+            {{- with .connectionTimeout }}
+              <connectionTimeout>{{ . }}</connectionTimeout>
+            {{- end }}
+            {{- with .socketTimeout }}
+              <socketTimeout>{{ . }}</socketTimeout>        
+            {{- end }
             {{- with .kmsServerSideEncryptionKeyId }}
               <kmsServerSideEncryptionKeyId>{{ . }}</kmsServerSideEncryptionKeyId>
             {{- end }}
@@ -1275,7 +1287,6 @@ artifactory:
       bucketExists: false
       useInstanceCredentials: false
       enableSignedUrlRedirect: false
-
     ## For artifactory.persistence.type aws-s3-v3
     awsS3V3:
       testConnection: false
@@ -1286,6 +1297,8 @@ artifactory:
       path: artifactory/filestore
       endpoint:
       maxConnections: 50
+      connectionTimeout: 20000
+      socketTimeout: 100000
       kmsServerSideEncryptionKeyId:
       kmsKeyRegion:
       kmsCryptoMode:
@@ -1298,7 +1311,9 @@ artifactory:
       cloudFrontPrivateKey:
       enableSignedUrlRedirect: false
       enablePathStyleAccess: false
-
+    remote:
+      connectionTimeout: 10000
+      socketTimeout: 30000
     ## For artifactory.persistence.type aws-s3
     ## IMPORTANT: Make sure S3 `endpoint` and `region` match! See https://docs.aws.amazon.com/general/latest/gr/rande.html
     awsS3:


### PR DESCRIPTION
Included connectionTimeout and socketTimeout for provider id="remote-s3 and s3-storage-v3" , as suggested by jfrog Artifactory Team

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR will add connectionTimeout, and  socketTimeout parameters for s3-storage-v3 Binary Provider,: which is suggested by JFrog artifactory team as a solution to improve performance and reduce timeout errors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
 there are so many timeouts  and the bad performance (e.g. CPU/Networking wise...) which are  tuning related (increase max connections pool and timeout values for the various binary providers) and are most likely rooted in your binarystore.xml configuration file

**Special notes for your reviewer**:

