### PR TITLE
[distribution] Fix Redis liveliness probe timeout

### DIFF
--- a/stable/distribution/CHANGELOG.md
+++ b/stable/distribution/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Distribution Chart Changelog
 All changes to this project chart be documented in this file.
 
+## [102.13.5] - July 15, 2022
+* Fixed - Distribution Redis container shuts down every minute [GH-1655](https://github.com/jfrog/charts/issues/1655)
+
 ## [102.13.4] - Apr 29, 2022
 * Fixed loggers sidecars to tail a configured log
 * Added silent option for curl probes

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -19,4 +19,4 @@ name: distribution
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 102.13.4
+version: 102.13.5

--- a/stable/distribution/templates/distribution-statefulset.yaml
+++ b/stable/distribution/templates/distribution-statefulset.yaml
@@ -454,14 +454,14 @@ spec:
           containerPort: {{ .Values.redis.port }}
         readinessProbe:
           initialDelaySeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 5
           exec:
             command:
             - redis-cli
             - ping
         livenessProbe:
           initialDelaySeconds: 30
-          timeoutSeconds: 1
+          timeoutSeconds: 5
           exec:
             command:
             - redis-cli


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Fixes a bug in the *distribution* Helm chart that made the Distribution service unusable.
I made some tests and found out that 2 seconds are still too low, 3 seconds were ok, but I wanted to have some buffer so I decided to take 5 seconds.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1655


**Special notes for your reviewer**:
@chukka 
