### PR TITLE
[distribution] add annotations to statefulset

### DIFF
--- a/stable/distribution/CHANGELOG.md
+++ b/stable/distribution/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Distribution Chart Changelog
 All changes to this project chart be documented in this file.
 
+## [102.15.1] -
+* Added support for annotations on the distribution statefulset [GH-1674](https://github.com/jfrog/charts/pull/1674)
+
 ## [102.15.0] - Aug 25, 2022
 * Updated router version to `7.45.0`
 * Added flag `distribution.schedulerName` to set for the pods the value of schedulerName field [GH-1606](https://github.com/jfrog/charts/issues/1606)

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -19,4 +19,4 @@ name: distribution
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 102.15.0
+version: 102.15.1

--- a/stable/distribution/ci/test-values.yaml
+++ b/stable/distribution/ci/test-values.yaml
@@ -54,6 +54,9 @@ distribution:
     xmx: "3g"
   priorityClass:
     create: true
+  statefulset:
+    annotations:
+      distribution: test
 
 # Init containers
 initContainers:

--- a/stable/distribution/templates/distribution-statefulset.yaml
+++ b/stable/distribution/templates/distribution-statefulset.yaml
@@ -17,6 +17,10 @@ metadata:
 {{- if and .Release.IsUpgrade .Values.postgresql.enabled }}
     databaseUpgradeReady: {{ required "\n\n*********\nIMPORTANT: UPGRADE STOPPED to prevent data loss!\nReview CHANGELOG.md (https://github.com/jfrog/charts/blob/master/stable/distribution/CHANGELOG.md), pass postgresql.image.tag '9.6.18-debian-10-r7' or '10.13.0-debian-10-r38' and databaseUpgradeReady=true if you are upgrading from chart version which has postgresql version 9.6.x or 10.13.x" .Values.databaseUpgradeReady | quote }}
 {{- end }}
+{{- with .Values.distribution.statefulset.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "distribution.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}

--- a/stable/distribution/values.yaml
+++ b/stable/distribution/values.yaml
@@ -451,6 +451,9 @@ distribution:
   service:
     type: ClusterIP
 
+  statefulset:
+    annotations: {}
+
   ## Add custom volumeMounts
   customVolumeMounts: |
   #  - name: custom-script


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Adds support for annotations on statefulsets in addition to the pod specs that were already present. This is helpful when interacting with other tooling on the deployment clusters that function via annotations.

**Special notes for your reviewer**:
This splits out the Distribution changes from https://github.com/jfrog/charts/pull/1665
