### PR TITLE
Add example for fluent-bit sidecar logging

### DIFF
--- a/examples/artifactory/logging/README.md
+++ b/examples/artifactory/logging/README.md
@@ -1,0 +1,22 @@
+# Setting up a logging sidecar
+Due to the nature of Artifactory running with many services, each writing multiple logs to the file system, it's hard to collect them all in a Kubernetes based deployment.<br>
+The example in this directory has an example of using a [fluent-bit](https://fluentbit.io/) sidecar that collects all logs from Artifactory's `log/` directory and writes them to STDOUT in a nice json formatted way
+
+See the [values-logging-fluent-bit.yaml](values-logging-fluent-bit.yaml) for the configuration example
+
+## Deploy
+Install Artifactory with the following command
+```shell
+helm upgrade --install artifactory jfrog/artifactory -f values-logging-fluent-bit.yaml
+```
+
+## Fluent-bit STDOUT
+Once running, the `fluent-bit` sidecar tails the logs in the configured directories and outputs them to the container's STDOUT in a json format.<br>
+Each line had a `"file"` key that lists the source file, which later can be used to separate the sources.<br>
+The actual log line is in the `"log"` key.
+```json
+{"date":1683099717.440138,"file":"/var/opt/jfrog/artifactory/log/frontend-service.log","log":"2023-05-03T07:41:57.435Z [jffe ] [INFO ] [] [frontend-service.log] [main ] - pinging artifactory, attempt number 1"}
+```
+
+## Cluster log collector
+Once this is setup, you need to configure your cluster log collector (probably running as a DaemonSet) to collect logs from this container only.

--- a/examples/artifactory/logging/values-logging-fluent-bit.yaml
+++ b/examples/artifactory/logging/values-logging-fluent-bit.yaml
@@ -1,0 +1,77 @@
+artifactory:
+
+  # Create extra config maps with the required fluent-bit configuration
+  configMaps: |
+    fluent-bit-input.conf: |-
+      [INPUT]
+          Name              tail
+          Path              /var/opt/jfrog/artifactory/log/*.log
+          DB                /var/opt/jfrog/fluentdb/fluentdb.db
+          Exclude_Path      *router-request.log,*console.log,*-metrics.log
+          Path_Key          file
+          Refresh_Interval  20
+          Multiline         On
+          Parser_Firstline  multiline_pattern
+          Skip_Long_Lines   On
+
+      [INPUT]
+          Name              tail
+          Path              /var/opt/jfrog/artifactory/log/tomcat/*.log
+          DB                /var/opt/jfrog/fluentdb/fluentdb.db
+          Path_Key          file
+          Refresh_Interval  20
+          Multiline         On
+          Parser_Firstline  multiline_pattern
+
+    fluent-bit-output.conf: |-
+      [OUTPUT]
+          Name   stdout
+          Match  *
+          Format json_lines
+
+    fluent-bit-service.conf: |-
+      [SERVICE]
+          Flush        1
+          Daemon       Off
+          Log_Level    info
+          Parsers_File parsers.conf
+
+    fluent-bit.conf: |-
+      @INCLUDE fluent-bit-service.conf
+      @INCLUDE fluent-bit-input.conf
+      @INCLUDE fluent-bit-output.conf
+
+    parsers.conf: |-
+      [PARSER]
+          Name      multiline_pattern
+          Format    regex
+          Regex     ^(?<log>\d{2,4}\-\d{2,4}\-\d{2,4}T\d{2,4}\:\d{2,4}\:\d{2,4}\.\d{1,6}?.*)
+
+  # Create the extra sidecar container
+  customSidecarContainers: |
+    - name: artifactory-fluent-bit
+      image: "fluent/fluent-bit:2.1.2"
+      volumeMounts:
+      - mountPath: /var/opt/jfrog/artifactory
+        name: artifactory-volume
+      - mountPath: /var/opt/jfrog/fluentdb
+        name: fluentdb
+      - mountPath: /fluent-bit/etc/fluent-bit.conf
+        name: artifactory-configmaps
+        subPath: fluent-bit.conf
+      - mountPath: /fluent-bit/etc/fluent-bit-service.conf
+        name: artifactory-configmaps
+        subPath: fluent-bit-service.conf
+      - mountPath: /fluent-bit/etc/fluent-bit-input.conf
+        name: artifactory-configmaps
+        subPath: fluent-bit-input.conf
+      - mountPath: /fluent-bit/etc/fluent-bit-output.conf
+        name: artifactory-configmaps
+        subPath: fluent-bit-output.conf
+      - mountPath: /fluent-bit/etc/parsers.conf
+        name: artifactory-configmaps
+        subPath: parsers.conf
+
+  customVolumes: |
+    - name: fluentdb
+      emptyDir: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
An example of how to configure a fluent-bit sidecar for all logs collection in Artifactory using a custom `values-logging-fluent-bit.yaml`


