### PR TITLE
[xray] disable securepassword to allow deploy succesfully

### DIFF
--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 3.71.6
+appVersion: 3.71.7
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
@@ -24,4 +24,4 @@ name: xray
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 103.71.6
+version: 103.71.7

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -395,6 +395,7 @@ rabbitmq:
   auth:
     username: guest
     password: password
+    securePassword: false
     ## Alternatively, you can use a pre-existing secret with a key called rabbitmq-password by specifying existingPasswordSecret
     # existingPasswordSecret: <name-of-existing-secret>
     erlangCookie: XRAYRABBITMQCLUSTER


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

current rabbitmq for xray doesnt work with RABBITMQ_SECURE_PASSWORD=yes and RABBITMQ_LOAD_DEFINITIONS=yes at the same time, XRAY require RABBITMQ_LOAD_DEFINITIONS , so we need to enforce the RABBITMQ_SECURE_PASSWORD=no since by default the  RABBITMQ_SECURE_PASSWORD is set to yes when we set a value on rabbitmq.auth.password!=""
we need to set this value by default so new version can be deployed easily without having to troubleshoot this error 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

havent found a pr that talk about this feature yet 

**Special notes for your reviewer**:

this issue started to happen on the bump of rabbitmq version used xray 