### PR TITLE
[xray] add GOMAXPROCS env in statefulset from limits.cpu values

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [103.76.0] - Jun 22, 2023
+* Add GOMAXPROCS env configuration from `limits.cpu` for router, analysis, indexer, server, persist in sts.
+
 ## [103.75.12] - May 19, 2023
 * Fix lint issue when rabbitmq is disabled
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -24,4 +24,4 @@ name: xray
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 103.75.12
+version: 103.76.0

--- a/stable/xray/templates/xray-statefulset.yaml
+++ b/stable/xray/templates/xray-statefulset.yaml
@@ -253,6 +253,11 @@ spec:
         env:
         - name: JF_ROUTER_TOPOLOGY_LOCAL_REQUIREDSERVICETYPES
           value: {{ include "xray.router.requiredServiceTypes" . }}
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: {{ .Values.router.name }}
+              resource: limits.cpu
         ports:
           - name: http-router
             containerPort: {{ .Values.router.internalPort }}
@@ -450,6 +455,11 @@ spec:
               name: "{{ template "xray.name" . }}-unified-secret"
               {{- end }}
               key: execution-service-aes-key
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: {{ .Values.server.name }}
+              resource: limits.cpu
         {{- if .Values.common.extraEnvVars }}
         {{- tpl .Values.common.extraEnvVars . | nindent 8 }}
         {{- end }}
@@ -615,6 +625,11 @@ spec:
               name: "{{ template "xray.name" . }}-unified-secret"
               {{- end }}
               key: execution-service-aes-key
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: {{ .Values.analysis.name }}
+              resource: limits.cpu
         {{- if .Values.common.extraEnvVars }}
         {{- tpl .Values.common.extraEnvVars . | nindent 8 }}
         {{- end }}
@@ -769,6 +784,11 @@ spec:
               fieldPath: metadata.name
         - name: XRAY_K8S_ENV
           value: "true"
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: {{ .Values.indexer.name }}
+              resource: limits.cpu
         {{- if .Values.common.extraEnvVars }}
         {{- tpl .Values.common.extraEnvVars . | nindent 8 }}
         {{- end }}
@@ -919,6 +939,11 @@ spec:
       {{- end }}
         - name: XRAY_K8S_ENV
           value: "true"
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: {{ .Values.persist.name }}
+              resource: limits.cpu
         {{- if .Values.common.extraEnvVars }}
         {{- tpl .Values.common.extraEnvVars . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

Settings GOMAXPROCS is a good practice for running go applications in kubernetes.

Customers who are running xray on kubernetes with cgroup v2 can encounter some performance issue due to cgroup v2 cpu management for go application.

For more information see theses post :
- https://blog.kintone.io/entry/2022/03/08/170206#Go
- https://engineering.grab.com/performance-bottlenecks-go-apps

