### PR TITLE
[xray] add defaultRetentionDaysForIndexedRepo support

### DIFF
--- a/stable/xray/CHANGELOG.md
+++ b/stable/xray/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Xray Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [103.84.0] - Oct 14, 2023
+* Added `server.defaultRetentionDaysForIndexedRepo` as optional fields
+
 ## [103.83.9] - Sep 15,2023
 * Fixed - Support to configure privateRegistry for pre-upgrade-hook
 

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -24,4 +24,4 @@ name: xray
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 103.83.9
+version: 103.84.0

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -225,6 +225,10 @@ xray:
       {{- if .Values.server.indexAllBuilds }}
       indexAllBuilds: {{ .Values.server.indexAllBuilds }}
       {{- end }}
+      {{- if .Values.server.defaultRetentionDaysForIndexedRepo }}
+      repo:
+        defaultRetentionDaysForIndexedRepo: {{ .Values.server.defaultRetentionDaysForIndexedRepo }}
+      {{- end }}
     {{- end }}
     {{- if (include "xray.imagePullSecretsStrList" .) }}
     executionService:
@@ -1112,6 +1116,7 @@ server:
 
   # mailServer: ""
   # indexAllBuilds: false
+  # defaultRetentionDaysForIndexedRepo: 90 
 
   ## Add custom volumesMounts
   customVolumeMounts: |


### PR DESCRIPTION
#### PR Checklist

- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

Currently the Xray indexing default retention period can be [defined in Xray System yaml](https://jfrog.com/help/r/jfrog-security-documentation/indexing-xray-resources) with server.repo.defaultRetentionDaysForIndexedRepo settings.

If we want to configure this settings, we have to override xray system yaml (see [systemYamlOverride](https://github.com/jfrog/charts/blob/master/stable/xray/values.yaml#L78)), so it would be great to be able to configure this setting via a value in the chart's values.yaml file.

**Which issue this PR fixes** : fixes #1832


