### PR TITLE
Use POST request for federation livenessProbe

### DIFF
--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -1385,7 +1385,7 @@ federation:
         command:
           - sh
           - -c
-          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} -XPOST http://localhost:{{ .Values.federation.internalPort }}/artifactory/service/rtfs/ping
+          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} -XPOST http://localhost:{{ .Values.federation.internalPort }}/rtfs/ping
       initialDelaySeconds: {{ if semverCompare "<v1.20.0-0" .Capabilities.KubeVersion.Version }}180{{ else }}0{{ end }}
       failureThreshold: 5
       timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
@@ -1398,7 +1398,7 @@ federation:
         command:
           - sh
           - -c
-          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} -XPOST http://localhost:{{ .Values.federation.internalPort }}/artifactory/service/rtfs/ping
+          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} -XPOST http://localhost:{{ .Values.federation.internalPort }}/rtfs/ping
       initialDelaySeconds: 30
       failureThreshold: 90
       periodSeconds: 5

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -1385,7 +1385,7 @@ federation:
         command:
           - sh
           - -c
-          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} http://localhost:{{ .Values.federation.internalPort }}/artifactory/service/rtfs/ping
+          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} -XPOST http://localhost:{{ .Values.federation.internalPort }}/artifactory/service/rtfs/ping
       initialDelaySeconds: {{ if semverCompare "<v1.20.0-0" .Capabilities.KubeVersion.Version }}180{{ else }}0{{ end }}
       failureThreshold: 5
       timeoutSeconds: {{ .Values.probes.timeoutSeconds }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -1398,7 +1398,7 @@ federation:
         command:
           - sh
           - -c
-          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} http://localhost:{{ .Values.federation.internalPort }}/artifactory/service/rtfs/ping
+          - curl --fail --max-time {{ .Values.probes.timeoutSeconds }} -XPOST http://localhost:{{ .Values.federation.internalPort }}/artifactory/service/rtfs/ping
       initialDelaySeconds: 30
       failureThreshold: 90
       periodSeconds: 5


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

It appears the `/rtfs/sync/ping` endpoint must be hit with a `POST` request instead of a `GET` request.

```
2023-12-07T15:11:24.336Z [jfrtfs] [ERROR] [               ] [.r.r.GlobalExceptionHandler:27] [http-nio-8085-exec-7] - Caught an error - Request method 'GET' is not supported
```

```
$ curl localhost:8085/rtfs/sync/ping
{"status":400,"message":"Request method 'GET' is not supported","traceId":"traceId"}

$ curl -XPOST localhost:8085/rtfs/sync/ping
{"status":200,"message":"PONG","traceId":"Take trace id"}
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

