### PR TITLE
[artifactory] Add the ability to set `signedUrlExpirySeconds` to google providers

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [107.77.4] - Feb 02, 2024
+* Added `signedUrlExpirySeconds` option to artifactory.persistence.type of `google-storage`, `google-storage-v2`, and `google-storage-v2-direct`
+
 ## [107.77.3] - Jan 16, 2024
 * Removed integration service
 * Added recommended postgresql sizing configurations under sizing directory

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -21,4 +21,4 @@ name: artifactory
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 107.77.3
+version: 107.77.4

--- a/stable/artifactory/files/binarystore.xml
+++ b/stable/artifactory/files/binarystore.xml
@@ -155,6 +155,9 @@
         <bucketName>{{ .Values.artifactory.persistence.googleStorage.bucketName }}</bucketName>
         <path>{{ .Values.artifactory.persistence.googleStorage.path }}</path>
         <bucketExists>{{ .Values.artifactory.persistence.googleStorage.bucketExists }}</bucketExists>
+        {{- if .Values.artifactory.persistence.googleStorage.signedUrlExpirySeconds }}
+        <signedUrlExpirySeconds>{{ .Values.artifactory.persistence.googleStorage.signedUrlExpirySeconds }}</signedUrlExpirySeconds>
+        {{- end }}
     </provider>
 </config>
 {{- end }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

We are using the `google-storage-v2-direct` provider and were previously providing a custom binary store with a `signedUrlExpirySeconds` set to `120`. We recently switched to the chart-provided binary store config and can no longer control the signed URL expiry. As such, we are now using the provider default of `30`.

We've recently ran into issues where we would like to increase the expiry a bit, and we're not currently able to due to the binary store template provided by the chart not providing this ability. We would rather not go back to a custom-defined binary store config, so I'm raising this PR to address that.

**Special notes for your reviewer**:

I made `signedUrlExpirySeconds` conditional on the value being set in a Helm deployment. I was going to add `.artifactory.persistence.googleStorage.signedUrlExpirySeconds: 30` to [/stable/artifactory/values.yaml](https://github.com/jfrog/charts/blob/master/stable/artifactory/values.yaml#L941), and remove the conditional from the binary store template, but figured this approach would be better so that, if not set, we can just rely on the built-in provider default without having to manage it within this Helm chart.