### PR TITLE
[artifactory-ha] Fix missing volume on member nodes when using gcpServiceAccount.customSecretName

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,12 +1,13 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file
 
-## [107.77.11] - April 22, 2024
+## [107.77.12] - May 3, 2024
 * Removed integration service
 * Added recommended postgresql sizing configurations under sizing directory
 * Updated artifactory-federation (probes, port, embedded mode)
 * Fixing broken nginx port [GH-1860](https://github.com/jfrog/charts/issues/1860)
 * Added nginx.customCommand to use custom commands for the nginx container
+* Fix broken customSecretName for member nodes [GH-1873](https://github.com/jfrog/charts/issues/1873)
 
 ## [107.76.0] - Dec 13, 2023
 * Added connectionTimeout and socketTimeout paramaters under AWSS3 binarystore section

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 7.77.11
+appVersion: 7.77.12
 dependencies:
 - condition: postgresql.enabled
   name: postgresql

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -1176,6 +1176,11 @@ spec:
         secret:
           secretName: {{ .Values.artifactory.license.secret }}
       {{- end }}
+      {{- if and .Values.artifactory.persistence.googleStorage.gcpServiceAccount.enabled .Values.artifactory.persistence.googleStorage.gcpServiceAccount.customSecretName }}
+      - name: gcpcreds-json
+        secret:
+          secretName: {{ .Values.artifactory.persistence.googleStorage.gcpServiceAccount.customSecretName }}
+      {{- end }}
 
       ############ Config map, Volumes and Custom Volumes ##############
       {{- if .Values.artifactory.migration.enabled }}


### PR DESCRIPTION
Previously, only the volumeMount was created, but not the volume itself. This affected only member nodes, not primary nodes.

Fixes: https://github.com/jfrog/charts/issues/1873

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)