### PR TITLE
[artifactory-ha] set as version value after the last colon

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory-ha Chart Changelog
 All changes to this chart will be documented in this file
 
+## [107.84.13] - June 11, 2024
+* Fix incorrect capture group in helper function defining chart version
+
 ## [107.84.12] - May 20, 2024
 * Added image section for `initContainers` instead of `initContainerImage`
 * Renamed `router.image.imagePullPolicy` to `router.image.pullPolicy`

--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file
 
 ## [107.84.13] - June 11, 2024
-* Fix incorrect capture group in helper function defining chart version
+* Fix incorrect capture group in the helper function that sets chart version
 
 ## [107.84.12] - May 20, 2024
 * Added image section for `initContainers` instead of `initContainerImage`

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   artifactoryServiceVersion: 7.84.16
 apiVersion: v2
-appVersion: 7.84.12
+appVersion: 7.84.13
 dependencies:
 - condition: postgresql.enabled
   name: postgresql

--- a/stable/artifactory-ha/templates/_helpers.tpl
+++ b/stable/artifactory-ha/templates/_helpers.tpl
@@ -321,8 +321,9 @@ Return the proper artifactory chart image names
 Return the proper artifactory app version
 */}}
 {{- define "artifactory-ha.app.version" -}}
-{{- $image := split ":" ((include "artifactory-ha.getImageInfoByValue" (list . "artifactory")) | toString) -}}
-{{- $tag := $image._1 -}}
+{{- $image := (include "artifactory-ha.getImageInfoByValue" (list . "artifactory")) | toString -}}
+{{- $parts := splitList ":" $image -}}
+{{- $tag := index $parts (sub (len $parts) 1) -}}
 {{- printf "%s" $tag -}}
 {{- end -}}
 


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: incorrect value is set as a chart version when images are downloaded from DNS containing the port number, which makes helm deployment impossible without fixing the chart with kustomize
 (e.g. in case of 'test.jfrog.io:8085/example:123' in the artifactory-ha statefulset the version is set as '8085/example' instead of '123')


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

