### PR TITLE
[jfrog-platform] Added podSecurityContext and containerSecurityContext for pre-upgrade-check migration hook container

### DIFF
--- a/stable/jfrog-platform/CHANGELOG.md
+++ b/stable/jfrog-platform/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Platform Chart Changelog (GA releases only)
 All changes to this chart will be documented in this file.
 
+## [10.19.7] - Oct 14, 2024
+* Fixed - Added podSecurityContext and containerSecurityContext for pre-upgrade-check migration hook container
+
 ## [10.19.6] - Oct 8, 2024
 * Fixed typo to get fourth parameter for setupPostgres.sh [GH-1992](https://github.com/jfrog/charts/pull/1992)
 * Added `preUpgradeHook.tolerations`

--- a/stable/jfrog-platform/Chart.yaml
+++ b/stable/jfrog-platform/Chart.yaml
@@ -50,4 +50,4 @@ name: jfrog-platform
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 10.19.6
+version: 10.19.7

--- a/stable/jfrog-platform/templates/upgrade-hook.yaml
+++ b/stable/jfrog-platform/templates/upgrade-hook.yaml
@@ -87,6 +87,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "jfrog-platform.fullname" . }}
+      {{- if .Values.preUpgradeHook.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.preUpgradeHook.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       {{- include "jfrog-platform.imagePullSecrets" . | indent 6 }}
       {{- end }}
@@ -94,6 +97,9 @@ spec:
         - name: pre-upgrade-check
           image: "{{ tpl .Values.preUpgradeHook.image.registry . }}/{{ .Values.preUpgradeHook.image.repository }}:{{ .Values.preUpgradeHook.image.tag }}"
           imagePullPolicy: {{ .Values.preUpgradeHook.image.pullPolicy }}
+          {{- if .Values.preUpgradeHook.containerSecurityContext.enabled }}
+          securityContext: {{- tpl (omit .Values.preUpgradeHook.containerSecurityContext "enabled" | toYaml) . | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.preUpgradeHook.resources | indent 12 }}
           command:

--- a/stable/jfrog-platform/values.yaml
+++ b/stable/jfrog-platform/values.yaml
@@ -103,6 +103,10 @@ rabbitmq:
   image:
     repository: bitnami/rabbitmq
     tag: 3.12.10-debian-11-r1
+  podSecurityContext:
+    enabled: false
+  containerSecurityContext:
+    enabled: false
   auth:
   ## Enable encryption to rabbitmq
   ## ref: https://www.rabbitmq.com/ssl.html
@@ -242,6 +246,11 @@ artifactory:
     url: '{{ include "database.url" . }}'
     user: artifactory
     password: artifactory
+  ingress:
+    enabled: false
+  nginx:
+    service:
+      type: ""
   # Note: For artifactory Pro license, mission-control is not supported, Hence, set mc.enabled: false
   # Note: mission-control is disabled by default, this is only available for E+ customers, and can be enabled by setting mc.enabled: true
   mc:
@@ -359,6 +368,10 @@ preUpgradeHook:
     repository: bitnami/kubectl
     tag: 1.24.12
     pullPolicy: IfNotPresent
+  podSecurityContext:
+    enabled: false
+  containerSecurityContext:
+    enabled: false
   resources:
     requests:
       cpu: 5m


### PR DESCRIPTION

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The new pre-upgrade-check pod and container is missing the option to set security context settings. On clusters that require more strict settings the pre-upgrade-check can not be started:
```
violates PodSecurity'

	(combined from similar events): Error creating: pods "jfrog-platform-pre-upgrade-check-j527c" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "pre-upgrade-check" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "pre-upgrade-check" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "pre-upgrade-check" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "pre-upgrade-check" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```



**Special notes for your reviewer**:

