### PR TITLE
[Artifactory] Expanding CustomVolumeMounts Parameter

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [107.98.14] - Jan 9, 2025
+* Add support for `customvolumemounts` for JFconnect, Obsvervability, Access, and Event containers
+
 ## [107.98.13] - Nov 06, 2024
 * Add support for `extraEnvironmentVariables` on filebeat Sidecar [GH-1377](https://github.com/jfrog/charts/pull/1377)
 * Support for SSL offload HTTPS proto override in Nginx service (ClusterIP, LoadBalancer) layer. Introduced `nginx.service.ssloffloadForceHttps` field with boolean type. [GH-1906](https://github.com/jfrog/charts/pull/1906)

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -21,4 +21,4 @@ name: artifactory
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 107.98.13
+version: 107.98.14

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -552,9 +552,9 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ .Values.router.persistence.mountPath | quote }}
-{{- with .Values.router.customVolumeMounts }}
-{{ tpl . $ | indent 8 }}
-{{- end }}
+        {{- if or .Values.router.customVolumeMounts .Values.global.customVolumeMounts }}
+{{ tpl (include "router.customVolumeMounts" .) . | indent 8 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.router.resources | indent 10 }}
       {{- if .Values.router.startupProbe.enabled }}
@@ -600,6 +600,9 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
+        {{- if or .Values.artifactory.customVolumeMounts .Values.global.customVolumeMounts }}
+{{ tpl (include "artifactory.customVolumeMounts" .) . | indent 8 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
       {{- if .Values.frontend.startupProbe.enabled }}
@@ -824,6 +827,9 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
+        {{- if or .Values.artifactory.customVolumeMounts .Values.global.customVolumeMounts }}
+{{ tpl (include "artifactory.customVolumeMounts" .) . | indent 8 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.event.resources | indent 10 }}
       {{- if .Values.event.startupProbe.enabled }}
@@ -862,6 +868,9 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
+        {{- if or .Values.artifactory.customVolumeMounts .Values.global.customVolumeMounts }}
+{{ tpl (include "artifactory.customVolumeMounts" .) . | indent 8 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.jfconnect.resources | indent 10 }}
       {{- if .Values.jfconnect.startupProbe.enabled }}
@@ -1039,6 +1048,9 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
+        {{- if or .Values.artifactory.customVolumeMounts .Values.global.customVolumeMounts }}
+{{ tpl (include "artifactory.customVolumeMounts" .) . | indent 8 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.federation.resources | indent 10 }}
       {{- if .Values.federation.startupProbe.enabled }}
@@ -1077,6 +1089,9 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
+        {{- if or .Values.artifactory.customVolumeMounts .Values.global.customVolumeMounts }}
+{{ tpl (include "artifactory.customVolumeMounts" .) . | indent 8 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.observability.resources | indent 10 }}
       {{- if .Values.observability.startupProbe.enabled }}

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -552,8 +552,8 @@ spec:
         volumeMounts:
         - name: artifactory-volume
           mountPath: {{ .Values.router.persistence.mountPath | quote }}
-        {{- if or .Values.router.customVolumeMounts .Values.global.customVolumeMounts }}
-{{ tpl (include "router.customVolumeMounts" .) . | indent 8 }}
+        {{- if or .Values.artifactory.customVolumeMounts .Values.global.customVolumeMounts }}
+{{ tpl (include "artifactory.customVolumeMounts" .) . | indent 8 }}
         {{- end }}
         resources:
 {{ toYaml .Values.router.resources | indent 10 }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md
* confluence is not allowing me to make changes
- [X] Title of the PR starts with chart name (e.g. `[artifactory]`)


**What this PR does / why we need it**:
This PR is related to support tickets [333456](https://support.jfrog.com/s/tickets/500Tc00000Jl7ZP) and [313254](https://support.jfrog.com/s/tickets/500Tc00000CVKtB). It adds the ability to apply custom volume mounts to Jfconnect, Access, Observability, and Event containers. WE need this because all containers should have the ability to apply extra volumes. In our use case the listed containers require our TLS certificates to communicate past our firewall.


**Special notes for your reviewer**:
not able to lint as the brew kubelav package is no longer available
