### PR TITLE
[xray]: Isolate Ipa replica count from the xray-statefulset replicaCo…

### DIFF
--- a/stable/xray/templates/xray-ipa-deployment.yaml
+++ b/stable/xray/templates/xray-ipa-deployment.yaml
@@ -25,7 +25,7 @@ metadata:
 {{- end }}
 spec:
 {{- if not .Values.autoscalingIpa.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCountIpa }}
 {{- end }}
 {{- with .Values.deployment.strategy }}
   strategy:

--- a/stable/xray/values.yaml
+++ b/stable/xray/values.yaml
@@ -1630,6 +1630,7 @@ splitXraytoSeparateDeployments:
  ## To prevent downtime (both the statefulset pod and deployment pod are kept together, with gradual upgrade set to false, which can turn off statefulsets in subsequent upgrades)
  gradualUpgrade: false
 replicaCountServer: 2
+replicaCountIpa: 2
 ## Apply horizontal pod auto scaling on Xray server pods
 ## Only applicable when (splitXraytoSeparateDeployments.enabled) is set to true
 ## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
…unt to correlate replicaCountServer from xray-server-deployment

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
What this PR does - Adds an option to control the IPA replica count separately from the general .Values.replicaCount setting.
 
Why we need it:
When comparing xray-server-deployment and xray-ipa-deployment, it appears that a new key was introduced to manage server replica counts, but a similar option was not implemented for IPA replicas.
Current behavior:
xray-server-deployment:
- if not .Values.autoscalingServer.enabled 
  replicas: {{ .Values.replicaCountServer }}
- end  

xray-ipa-deployment:
- if not .Values.autoscalingIpa.enabled 
  replicas: {{ .Values.replicaCount }}
- end  

This update ensures consistent control over replica counts for both deployments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

