### PR TITLE
[artifactory] Add `metadata.namespace` to chart templates

### DIFF
--- a/stable/artifactory/templates/admin-bootstrap-creds.yaml
+++ b/stable/artifactory/templates/admin-bootstrap-creds.yaml
@@ -4,6 +4,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "artifactory.fullname" . }}-bootstrap-creds
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-access-config.yaml
+++ b/stable/artifactory/templates/artifactory-access-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "artifactory.fullname" . }}-access-config
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-binarystore-secret.yaml
+++ b/stable/artifactory/templates/artifactory-binarystore-secret.yaml
@@ -3,6 +3,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "artifactory.fullname" . }}-binarystore
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-configmaps.yaml
+++ b/stable/artifactory/templates/artifactory-configmaps.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "artifactory.fullname" . }}-configmaps
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/artifactory/templates/artifactory-custom-secrets.yaml
+++ b/stable/artifactory/templates/artifactory-custom-secrets.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "artifactory.fullname" $ }}-{{ .name }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     app: "{{ template "artifactory.name" $ }}"
     chart: "{{ template "artifactory.chart" $ }}"

--- a/stable/artifactory/templates/artifactory-database-secrets.yaml
+++ b/stable/artifactory/templates/artifactory-database-secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "artifactory.fullname" . }}-database-creds
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-gcp-credentials-secret.yaml
+++ b/stable/artifactory/templates/artifactory-gcp-credentials-secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "artifactory.fullname" . }}-gcpcreds
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-hpa.yaml
+++ b/stable/artifactory/templates/artifactory-hpa.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "artifactory.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/stable/artifactory/templates/artifactory-installer-info.yaml
+++ b/stable/artifactory/templates/artifactory-installer-info.yaml
@@ -2,6 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ template "artifactory.fullname" . }}-installer-info
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-license-secret.yaml
+++ b/stable/artifactory/templates/artifactory-license-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "artifactory.fullname" $ }}-license
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" $ }}
     chart: {{ template "artifactory.chart" $ }}

--- a/stable/artifactory/templates/artifactory-migration-scripts.yaml
+++ b/stable/artifactory/templates/artifactory-migration-scripts.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "artifactory.fullname" . }}-migration-scripts
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-networkpolicy.yaml
+++ b/stable/artifactory/templates/artifactory-networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "artifactory.fullname" $ }}-{{ .name }}-networkpolicy
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" $ }}
     chart: {{ template "artifactory.chart" $ }}

--- a/stable/artifactory/templates/artifactory-nfs-pvc.yaml
+++ b/stable/artifactory/templates/artifactory-nfs-pvc.yaml
@@ -30,6 +30,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "artifactory.fullname" . }}-data-pvc
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}
@@ -80,6 +81,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "artifactory.fullname" . }}-backup-pvc
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-pdb.yaml
+++ b/stable/artifactory/templates/artifactory-pdb.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "artifactory.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-role.yaml
+++ b/stable/artifactory/templates/artifactory-role.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "artifactory.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
 rules:
 {{ toYaml .Values.rbac.role.rules }}
 {{- end }}

--- a/stable/artifactory/templates/artifactory-rolebinding.yaml
+++ b/stable/artifactory/templates/artifactory-rolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "artifactory.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "artifactory.serviceAccountName" . }}

--- a/stable/artifactory/templates/artifactory-secrets.yaml
+++ b/stable/artifactory/templates/artifactory-secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "artifactory.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-service-grpc.yaml
+++ b/stable/artifactory/templates/artifactory-service-grpc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "artifactory.serviceGrpc.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-service.yaml
+++ b/stable/artifactory/templates/artifactory-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "artifactory.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-serviceaccount.yaml
+++ b/stable/artifactory/templates/artifactory-serviceaccount.yaml
@@ -13,5 +13,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "artifactory.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "artifactory.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-system-yaml.yaml
+++ b/stable/artifactory/templates/artifactory-system-yaml.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "artifactory.fullname" . }}-systemyaml
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/artifactory-unified-secret.yaml
+++ b/stable/artifactory/templates/artifactory-unified-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "artifactory.unifiedSecretPrependReleaseName" . }}-unified-secret
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     app: "{{ template "artifactory.name" $ }}"
     chart: "{{ template "artifactory.chart" $ }}"

--- a/stable/artifactory/templates/filebeat-configmap.yaml
+++ b/stable/artifactory/templates/filebeat-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "artifactory.fullname" . }}-filebeat-config
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/artifactory/templates/ingress-grpc.yaml
+++ b/stable/artifactory/templates/ingress-grpc.yaml
@@ -12,6 +12,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $ingressName }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/ingress.yaml
+++ b/stable/artifactory/templates/ingress.yaml
@@ -14,6 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $ingressName }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/logger-configmap.yaml
+++ b/stable/artifactory/templates/logger-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "artifactory.fullname" . }}-logger
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-artifactory-conf.yaml
+++ b/stable/artifactory/templates/nginx-artifactory-conf.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "artifactory.fullname" . }}-nginx-artifactory-conf
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-certificate-secret.yaml
+++ b/stable/artifactory/templates/nginx-certificate-secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: kubernetes.io/tls
 metadata:
   name: {{ template "artifactory.fullname" . }}-nginx-certificate
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-conf.yaml
+++ b/stable/artifactory/templates/nginx-conf.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "artifactory.fullname" . }}-nginx-conf
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: {{ .Values.nginx.kind }}
 metadata:
   name: {{ template "artifactory.nginx.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-pdb.yaml
+++ b/stable/artifactory/templates/nginx-pdb.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "artifactory.nginx.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-pvc.yaml
+++ b/stable/artifactory/templates/nginx-pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "artifactory.nginx.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-scripts-conf.yaml
+++ b/stable/artifactory/templates/nginx-scripts-conf.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "artifactory.fullname" . }}-nginx-scripts
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/nginx-service.yaml
+++ b/stable/artifactory/templates/nginx-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "artifactory.nginx.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/rtfs-deployment.yaml
+++ b/stable/artifactory/templates/rtfs-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "rtfs.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}

--- a/stable/artifactory/templates/rtfs-hpa.yaml
+++ b/stable/artifactory/templates/rtfs-hpa.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "rtfs.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/stable/artifactory/templates/rtfs-service.yaml
+++ b/stable/artifactory/templates/rtfs-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rtfs.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "artifactory.name" . }}
     chart: {{ template "artifactory.chart" . }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


**What this PR does / why we need it**:

When deploying kubernetes manifests via [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), errors are thrown because the `metadata.namespace` is missing. This PR adds this to all namespaced resources.

Examples of similar past MRs:
* https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1376
* https://github.com/bitnami/charts/pull/24284
* https://github.com/goharbor/harbor-helm/pull/1779