### PR TITLE
[artifactory] fix default value for customIngress so we don't get warnings

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,8 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+* Fix default value for `customIngress` to address helm warnings. [GH-2020](https://github.com/jfrog/charts/issues/2020)
+
 ## [107.117.14] - August 05, 2025
 * Added support for AWS S3 V3 credentials (identity and credential) from a Kubernetes Secret
 * Added support for Azure credentials (accountName and accountKey) from a Kubernetes Secret

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -139,7 +139,7 @@ ingress:
   ## This is an experimental feature, enabling this feature will route all traffic through the Router.
   disableRouterBypass: false
 ## Allows to add custom ingress
-customIngress: ""
+customIngress: {}
 ## There is a need to separate HTTP1.1 traffic from gRPC (HTTP2) to benefit
 ## 1. Use the Nginx keepalive for HTTP1.1
 ## 2. Keep gRPC over the HTTP2 connections only


### PR DESCRIPTION
#### PR Checklist
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

Whenever `customIngress` is specified, helm gives a warning about merging incompatible types (string and map).

**Which issue this PR fixes**:

fixes #2020


**Special notes for your reviewer**:
You can test the change before and after this `values.yaml` change with:

```sh
# before
helm template \
  --set customIngress.foo=bar \
  --set ingress.enabled=true \
  --show-only=templates/ingress.yaml \
  --version 107.111.12 \
  jfrog/artifactory

# after
helm dependency build stable/artifactory
helm template \
  --set customIngress.foo=bar \
  --set ingress.enabled=true \
  --show-only=templates/ingress.yaml \
  ./stable/artifactory
```
