### PR TITLE
Add the terraform state directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ examples/terraform/jfrog-platform-aws-install/jfrog-custom.yaml
 examples/terraform/jfrog-platform-aws-install/terraform.tfstate
 examples/terraform/jfrog-platform-aws-install/terraform.tfstate.backup
 examples/terraform/jfrog-platform-aws-install/terraform.tfvars
+examples/terraform/jfrog-platform-aws-install/state
 
 #
 tmp


### PR DESCRIPTION
Just added the `examples/terraform/jfrog-platform-aws-install/state` to `.gitignore`.