### PR TITLE
[artifactory] Consume persistence.annotations in volumeClaimTemplates

### DIFF
--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -2043,6 +2043,10 @@ spec:
   {{- if and .enabled (not .existingClaim) }}
   - metadata:
       name: artifactory-volume
+    {{- with .annotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     spec:
       {{- if .storageClassName }}
       {{- if (eq "-" .storageClassName) }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Currently, `.artifactory.persistence.annotations` is defined in `values.yaml`, but its value is unused. Placing annotations on volume claim templates is useful and sometimes necessary. For instance, when the backing storage uses a CSI driver that supports volume expansion where the parameters are controlled via annotations. This PR addresses this by consuming the already-defined `.artifactory.persistence.annotations` value in the artifactory statefulset's `.spec.volumeClaimTemplate` where appropriate.
