### PR TITLE
[catalog] Fix resources for router container in catalog

### DIFF
--- a/stable/catalog/templates/deployment.yaml
+++ b/stable/catalog/templates/deployment.yaml
@@ -219,8 +219,8 @@ spec:
         - name: router
           image: {{ template "router.image" . }}
           imagePullPolicy: {{ .Values.router.image.imagePullPolicy }}
-          {{- if .Values.containerSecurityContext.enabled }}
           resources: {{- toYaml .Values.router.resources | nindent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
           securityContext:
             {{- toYaml (omit .Values.containerSecurityContext "enabled") | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
resources in router container were only applied when containerSecurityContext was enabled.

