### PR TITLE
[artifactory] allow to use proxy protocol for nginx

### DIFF
--- a/stable/artifactory-ha/files/nginx-artifactory-conf.yaml
+++ b/stable/artifactory-ha/files/nginx-artifactory-conf.yaml
@@ -28,31 +28,31 @@ upstream artifactory {
 server {
 {{- if .Values.nginx.internalPortHttps }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.internalPortHttps }} ssl;
+listen [::]:{{ .Values.nginx.internalPortHttps }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- else -}}
-listen {{ .Values.nginx.internalPortHttps }} ssl;
+listen {{ .Values.nginx.internalPortHttps }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- end }}
 {{- else -}}
 {{- if .Values.nginx.https.enabled }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.https.internalPort }} ssl;
+listen [::]:{{ .Values.nginx.https.internalPort }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- else -}}
-listen {{ .Values.nginx.https.internalPort }} ssl;
+listen {{ .Values.nginx.https.internalPort }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.nginx.internalPortHttp }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.internalPortHttp }};
+listen [::]:{{ .Values.nginx.internalPortHttp }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- else -}}
-listen {{ .Values.nginx.internalPortHttp }};
+listen {{ .Values.nginx.internalPortHttp }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- end }}
 {{- else -}}
 {{- if .Values.nginx.http.enabled }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.http.internalPort }};
+listen [::]:{{ .Values.nginx.http.internalPort }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- else -}}
-listen {{ .Values.nginx.http.internalPort }};
+listen {{ .Values.nginx.http.internalPort }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/artifactory-ha/templates/_helpers.tpl
+++ b/stable/artifactory-ha/templates/_helpers.tpl
@@ -510,6 +510,14 @@ nginx scheme (http/https)
 {{- end -}}
 {{- end -}}
 
+{{/*
+Check usage of curl --haproxy-protocol flag
+*/}}
+{{- define "curl.haproxyprotocol" -}}
+{{ if or (and .Values.nginx.http.enabled .Values.nginx.httpUseProxyProtocol) (and (not .Values.nginx.http.enabled) .Values.nginx.httpsUseProxyProtocol) }}
+{{- printf "%s" "--haproxy-protocol" -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 nginx command

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -1933,6 +1933,10 @@ nginx:
   ssh:
     internalPort: 1339
     externalPort: 1339
+  # If proxy protocol is enabled, all connections to the particular scheme/port
+  # must use the proxy protocol, (including for example load balancer health checks).
+  httpUseProxyProtocol: false
+  httpsUseProxyProtocol: false
   ## The following settings are to configure the frequency of the liveness and readiness probes.
   livenessProbe:
     enabled: true
@@ -1941,7 +1945,7 @@ nginx:
         command:
           - sh
           - -c
-          - curl -s -k --fail --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/
+          - curl -s -k --fail {{ include "curl.haproxyprotocol" . }} --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 5
@@ -1954,7 +1958,7 @@ nginx:
         command:
           - sh
           - -c
-          - curl -s -k --fail --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
+          - curl -s -k --fail {{ include "curl.haproxyprotocol" . }} --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 5
@@ -1967,7 +1971,7 @@ nginx:
         command:
           - sh
           - -c
-          - curl -s -k --fail --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
+          - curl -s -k --fail {{ include "curl.haproxyprotocol" . }} --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
       initialDelaySeconds: 3
       failureThreshold: 90
       periodSeconds: 5

--- a/stable/artifactory/files/nginx-artifactory-conf.yaml
+++ b/stable/artifactory/files/nginx-artifactory-conf.yaml
@@ -28,31 +28,31 @@ upstream artifactory {
 server {
 {{- if .Values.nginx.internalPortHttps }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.internalPortHttps }} ssl;
+listen [::]:{{ .Values.nginx.internalPortHttps }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- else -}}
-listen {{ .Values.nginx.internalPortHttps }} ssl;
+listen {{ .Values.nginx.internalPortHttps }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- end }}
 {{- else -}}
 {{- if .Values.nginx.https.enabled }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.https.internalPort }} ssl;
+listen [::]:{{ .Values.nginx.https.internalPort }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- else -}}
-listen {{ .Values.nginx.https.internalPort }} ssl;
+listen {{ .Values.nginx.https.internalPort }} {{ if .Values.nginx.httpsUseProxyProtocol }}proxy_protocol{{ end }} ssl;
 {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.nginx.internalPortHttp }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.internalPortHttp }};
+listen [::]:{{ .Values.nginx.internalPortHttp }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- else -}}
-listen {{ .Values.nginx.internalPortHttp }};
+listen {{ .Values.nginx.internalPortHttp }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- end }}
 {{- else -}}
 {{- if .Values.nginx.http.enabled }}
 {{- if .Values.nginx.singleStackIPv6Cluster }}
-listen [::]:{{ .Values.nginx.http.internalPort }};
+listen [::]:{{ .Values.nginx.http.internalPort }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- else -}}
-listen {{ .Values.nginx.http.internalPort }};
+listen {{ .Values.nginx.http.internalPort }} {{ if .Values.nginx.httpUseProxyProtocol }}proxy_protocol{{ end }};
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/artifactory/templates/_helpers.tpl
+++ b/stable/artifactory/templates/_helpers.tpl
@@ -456,6 +456,15 @@ nginx scheme (http/https)
 {{- end -}}
 
 {{/*
+Check usage of curl --haproxy-protocol flag
+*/}}
+{{- define "curl.haproxyprotocol" -}}
+{{ if or (and .Values.nginx.http.enabled .Values.nginx.httpUseProxyProtocol) (and (not .Values.nginx.http.enabled) .Values.nginx.httpsUseProxyProtocol) }}
+{{- printf "%s" "--haproxy-protocol" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 nginx command
 */}}
 {{- define "nginx.command" -}}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -1765,6 +1765,10 @@ nginx:
   ssh:
     internalPort: 1339
     externalPort: 1339
+  # If proxy protocol is enabled, all connections to the particular scheme/port
+  # must use the proxy protocol, (including for example load balancer health checks).
+  httpUseProxyProtocol: false
+  httpsUseProxyProtocol: false
   ## DEPRECATED: The following will be removed in a future release
   # externalPortHttp: 8080
   # internalPortHttp: 8080
@@ -1779,7 +1783,7 @@ nginx:
         command:
           - sh
           - -c
-          - curl -s -k --fail --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/
+          - curl -s -k --fail {{ include "curl.haproxyprotocol" . }} --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
@@ -1792,7 +1796,7 @@ nginx:
         command:
           - sh
           - -c
-          - curl -s -k --fail --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
+          - curl -s -k --fail {{ include "curl.haproxyprotocol" . }} --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
@@ -1805,7 +1809,7 @@ nginx:
         command:
           - sh
           - -c
-          - curl -s -k --fail --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
+          - curl -s -k --fail {{ include "curl.haproxyprotocol" . }} --max-time {{ .Values.probes.timeoutSeconds }} {{ include "nginx.scheme" . }}://localhost:{{ include "nginx.port" . }}/router/api/v1/system/readiness
       initialDelaySeconds: 3
       failureThreshold: 90
       periodSeconds: 5


### PR DESCRIPTION
When using a load balancer in front of nginx it is often required to enable proxy protocol.
This commit adds the required configuration options to enable proxy protocol support in the nginx configuration.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

When using a load balancer in front of nginx it is often required to
enable proxy protocol.
This commit adds the required configuration options to enable proxy
protocol support in the nginx configuration.

