### PR TITLE
[distribution] Update README for Redis removal in 2.37.0 (INST-21313)

### DIFF
--- a/stable/distribution/README.md
+++ b/stable/distribution/README.md
@@ -3,12 +3,14 @@
 **IMPORTANT!** Our Helm Chart docs have moved to our main documentation site. Below you will find the basic instructions for installing Distribution. For all other information, refer to [Installing Distribution](https://jfrog.com/help/r/jfrog-installation-setup-documentation/installing-distribution).
 
 ## Prerequisites Details
-* Kubernetes 1.19+
+* Kubernetes 1.23+
 
 ## Chart Details
 This chart does the following:
 * Deploy PostgreSQL database
 * Deploy distribution
+
+> **Note:** From Distribution 2.37.0, Redis is no longer included in this chart. For more information, see the [Distribution 2.37.0 release notes](https://docs.jfrog.com/releases/docs/distribution-release-notes#distribution-2370).
 
 ## Requirements
 - A running Kubernetes cluster
@@ -44,6 +46,18 @@ To apply the chart with recommended sizing configurations :
 For small configurations :
 ```bash
 helm upgrade --install distribution jfrog/distribution -f sizing/distribution-small.yaml --namespace distribution --create-namespace
+```
+
+## Upgrading to Distribution 2.37.0 or Later
+
+From Distribution 2.37.0, Redis has been removed from the chart. For more details, please refer to the [Distribution 2.37.0 release notes](https://docs.jfrog.com/releases/docs/distribution-release-notes#distribution-2370).
+
+When upgrading from a version prior to 2.37.0, a pre-upgrade webhook (`distribution-upgrade-hook`) is automatically executed. This webhook handles the migration by deleting the existing StatefulSet with `--cascade=orphan` (preserving running pods) to allow the updated spec — which no longer includes Redis — to be applied cleanly.
+
+In most cases, no manual intervention is required. However, if the hook job fails (for example, due to RBAC permissions or image pull issues), you may need to manually delete the StatefulSet before retrying the upgrade:
+
+```bash
+kubectl delete statefulset <release-name>-distribution --cascade=orphan -n <namespace>
 ```
 
 ## Uninstalling Distribution


### PR DESCRIPTION
## What This PR Does

Updates `stable/distribution/README.md` to document the Redis removal introduced in Distribution 2.37.0 (chart version 102.37.0) and explain the automatic upgrade hook behavior for users upgrading from older versions.

Jira: INST-21313

---

## Changes

### Chart Details — Redis Removal Note

Added a callout note below the chart overview bullets informing users that Redis is no longer included from Distribution 2.37.0, with a link to the release notes.

### New Section — Upgrading to Distribution 2.37.0 or Later

Added a new upgrade section (inserted before "Uninstalling Distribution") that explains:
- Redis has been removed from the chart in 2.37.0
- A pre-upgrade hook (`distribution-upgrade-hook`) runs automatically when upgrading from < 102.37.0
- The hook deletes the existing StatefulSet with `--cascade=orphan` to preserve running pods while allowing the updated spec to be applied
- No manual intervention is required

---

## Files Changed

- **1 file:** `stable/distribution/README.md`
- **No changes** to chart templates, values, or other chart files

## Test Plan

- [x] Verify Markdown renders correctly (no broken formatting or links)
- [x] Confirm the upgrade hook section accurately matches the behavior in `distribution-upgrade-hook.yaml`
- [x] Confirm the release notes link resolves correctly