### PR TITLE
[artifactory] Expose podManagementPolicy and update PDB logic for HA deployments

### DIFF
--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -1,6 +1,10 @@
 # JFrog Artifactory Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [107.133.16] - Mar 11, 2026
+* Exposed `artifactory.podManagementPolicy` in values.yaml (default: `OrderedReady`). Set to `Parallel` to allow independent pod scaling without waiting for each pod to become Ready
+* Updated `artifactory-pdb.yaml`: a PDB is now created when any of `podManagementPolicy: Parallel`, `artifactory.minAvailable`, or `artifactory.maxUnavailable` is set. When `Parallel` is set or `maxUnavailable` is explicitly provided, the PDB uses `maxUnavailable` (defaulting to `1` if not set). Otherwise `minAvailable` is used. A PDB spec cannot have both fields set simultaneously
+
 ## [107.133.15] - Mar 11, 2026
 * Added Azure Workload Identity Support. Refer [here](https://jfrog.com/help/r/jfrog-installation-setup-documentation/azure-workload-identity)
 * Added `JF_ARTIFACTORY_TOMCAT_MAINTENANCECONNECTOR_HOST` to support httpGet probes for artifactory container

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -21,4 +21,4 @@ name: artifactory
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 107.133.15
+version: 107.133.16

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -47,6 +47,22 @@ For more details on configuring the filestore, Refer [here](https://jfrog.com/he
 helm upgrade --install artifactory jfrog/artifactory --set artifactory.replicaCount=3,artifactory.persistence.type=cluster-file-system --namespace artifactory --create-namespace
 ```
 
+#### Pod Management Policy
+By default the Artifactory StatefulSet uses `OrderedReady` pod management, meaning pods start sequentially and each must be `Ready` before the next begins. In HA deployments this can slow down scale-up and rolling restarts. Set `artifactory.podManagementPolicy` to `Parallel` to allow all pods to start and stop independently:
+```bash
+helm upgrade --install artifactory jfrog/artifactory --set artifactory.podManagementPolicy=Parallel --namespace artifactory
+```
+> **Note:** `podManagementPolicy` is an immutable StatefulSet field. Changing it on an existing deployment requires deleting the StatefulSet with `--cascade=orphan` before upgrading.
+
+#### Pod Disruption Budget
+A PodDisruptionBudget is created when `artifactory.minAvailable` is set. When `artifactory.podManagementPolicy` is `Parallel`, the PDB switches to `maxUnavailable` (controlled by `artifactory.maxUnavailable`, default: `1`) instead:
+```bash
+helm upgrade --install artifactory jfrog/artifactory --set artifactory.podManagementPolicy=Parallel,artifactory.maxUnavailable=1 --namespace artifactory
+```
+
+
+```
+
 ### Apply Sizing configurations to the Chart
 Note that sizings with more than one replica require an enterprise license for HA . Refer [here](https://jfrog.com/help/r/jfrog-installation-setup-documentation/high-availability)
 To apply the chart with recommended sizing configurations :

--- a/stable/artifactory/templates/artifactory-pdb.yaml
+++ b/stable/artifactory/templates/artifactory-pdb.yaml
@@ -21,4 +21,7 @@ spec:
       role: {{ template "artifactory.name" . }}
       release: {{ .Release.Name }}
   minAvailable: {{ .Values.artifactory.minAvailable }}
+  {{- if eq .Values.artifactory.podManagementPolicy "Parallel" }}
+  maxUnavailable: {{ .Values.artifactory.maxUnavailable }}
+  {{- end }}
 {{- end }}

--- a/stable/artifactory/templates/artifactory-pdb.yaml
+++ b/stable/artifactory/templates/artifactory-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.artifactory.minAvailable -}}
+{{- if or (eq .Values.artifactory.podManagementPolicy "Parallel") .Values.artifactory.minAvailable .Values.artifactory.maxUnavailable -}}
 {{- if semverCompare "<v1.21.0-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1beta1
 {{- else }}
@@ -20,8 +20,9 @@ spec:
       app: {{ template "artifactory.name" . }}
       role: {{ template "artifactory.name" . }}
       release: {{ .Release.Name }}
+  {{- if or (eq .Values.artifactory.podManagementPolicy "Parallel") .Values.artifactory.maxUnavailable }}
+  maxUnavailable: {{ .Values.artifactory.maxUnavailable | default 1 }}
+  {{- else }}
   minAvailable: {{ .Values.artifactory.minAvailable }}
-  {{- if eq .Values.artifactory.podManagementPolicy "Parallel" }}
-  maxUnavailable: {{ .Values.artifactory.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -70,6 +70,7 @@ spec:
   serviceName: {{ template "artifactory.servicePrependReleaseName" . }}
   replicas: {{ .Values.artifactory.replicaCount }}
   updateStrategy: {{- toYaml .Values.artifactory.updateStrategy | nindent 4 }}
+  podManagementPolicy: {{ .Values.artifactory.podManagementPolicy }}
   selector:
     matchLabels:
       app: {{ template "artifactory.name" . }}
@@ -718,7 +719,7 @@ spec:
           value: "0.0.0.0"
 {{- with .Values.frontend.extraEnvironmentVariables }}
 {{ tpl (toYaml .) $ | indent 8 }}
-{{- end }}   
+{{- end }}
         volumeMounts:
         {{- if or .Values.artifactory.customVolumeMounts .Values.global.customVolumeMounts }}
 {{ tpl (include "artifactory.customVolumeMounts" .) . | indent 8 }}
@@ -728,7 +729,7 @@ spec:
           mountPath: {{ .Values.artifactory.customPersistentVolumeClaim.mountPath }}
       {{- end }}
         - name: artifactory-volume
-          mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}    
+          mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
       {{- if .Values.frontend.startupProbe.enabled }}
@@ -1210,7 +1211,7 @@ spec:
         startupProbe:
 {{ tpl .Values.access.startupProbe.config . | indent 10 }}
         {{- end }}
-    {{- if semverCompare "<v1.20.0-0" .Capabilities.KubeVersion.Version }}   
+    {{- if semverCompare "<v1.20.0-0" .Capabilities.KubeVersion.Version }}
         {{- if .Values.access.readinessProbe.enabled }}
         readinessProbe:
 {{ tpl .Values.access.readinessProbe.config . | indent 10 }}
@@ -1671,7 +1672,7 @@ spec:
       {{- end }}
         - name: artifactory-volume
           mountPath: {{ .Values.artifactory.persistence.mountPath | quote }}
-        
+
         - name: tmp-volume
           mountPath: "/tmp"
 
@@ -1936,7 +1937,7 @@ spec:
         secret:
           secretName: {{ .Values.artifactory.license.secret }}
       {{- end }}
-      
+
       # user Plugin Secrets
       {{- if .Values.artifactory.userPluginSecrets }}
       - name: bootstrap-plugins

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -363,9 +363,9 @@ artifactory:
   labels: {}
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: OrderedReady # When set to Parallel, the default maxUnavailable is 1 by default, otherwise it's unset.
+  podManagementPolicy: OrderedReady
   # minAvailable: 1
-  maxUnavailable: 1
+  # maxUnavailable: 1  # When podManagementPolicy is Parallel and maxUnavailable is not set, defaults to 1
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   schedulerName:
   ## Create a priority class for the Artifactory pod or use an existing one

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -351,7 +351,7 @@ artifactory:
   unifiedSecretPrependReleaseName: true
   ## For HA installation, set this value > 1. This is only supported in Artifactory 7.25.x (appVersions) and above.
   replicaCount: 1
-  # minAvailable: 1
+
 
   ## Note that by default we use appVersion to get image tag/version
   image:
@@ -363,6 +363,9 @@ artifactory:
   labels: {}
   updateStrategy:
     type: RollingUpdate
+  podManagementPolicy: OrderedReady # When set to Parallel, the default maxUnavailable is 1 by default, otherwise it's unset.
+  # minAvailable: 1
+  maxUnavailable: 1
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   schedulerName:
   ## Create a priority class for the Artifactory pod or use an existing one


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

Exposes `artifactory.podManagementPolicy` in `values.yaml` (default: `OrderedReady`) so users
can set it to `Parallel` to allow independent pod scaling and faster rolling restarts in HA deployments.

Also updates the PDB logic in `artifactory-pdb.yaml` — a PDB is now created when any of
`podManagementPolicy: Parallel`, `artifactory.minAvailable`, or `artifactory.maxUnavailable` is set.
When `Parallel` is used or `maxUnavailable` is explicitly provided, the PDB uses `maxUnavailable`
(defaulting to `1`); otherwise it falls back to `minAvailable`. This ensures the PDB spec never
has both fields set simultaneously, which is a Kubernetes constraint.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- `podManagementPolicy` is an **immutable** field on a StatefulSet. Changing it on an existing
  deployment requires deleting the StatefulSet with `--cascade=orphan` before upgrading.
  This is called out in the README.
- The PDB `maxUnavailable`/`minAvailable` switching logic ensures only one of the two mutually
  exclusive fields is ever rendered in the PDB spec.
