### PR TITLE
Versions upgrades and small improvements

### DIFF
--- a/examples/terraform/jfrog-platform-aws-install/eks.tf
+++ b/examples/terraform/jfrog-platform-aws-install/eks.tf
@@ -38,7 +38,7 @@ module "eks" {
     eks_managed_node_group_defaults = {
         ami_type = var.ami_type
         iam_role_additional_policies = {
-            AmazonS3FullAccess = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+            AmazonS3FullAccess       = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
             AmazonEBSCSIDriverPolicy = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
         }
         pre_bootstrap_user_data = <<-EOF
@@ -49,9 +49,9 @@ module "eks" {
             xvda = {
                 device_name = "/dev/xvda"
                 ebs = {
-                    volume_type = "gp3"
-                    volume_size = 50
-                    throughput  = 125
+                    volume_type           = "gp3"
+                    volume_size           = var.eks_root_volume_size
+                    throughput            = var.eks_root_throughput
                     delete_on_termination = true
                 }
             }
@@ -66,44 +66,19 @@ module "eks" {
         artifactory = {
             name = "${var.env_name}-artifactory"
 
-            instance_types = [(
-                var.sizing == "large"   ? var.artifactory_node_size_large :
-                var.sizing == "xlarge"  ? var.artifactory_node_size_large :
-                var.sizing == "2xlarge" ? var.artifactory_node_size_large :
-                var.artifactory_node_size_default
-            )]
-            min_size     = 1
-            max_size     = 10
-            desired_size = (
-                var.sizing == "medium"  ? 2 :
-                var.sizing == "large"   ? 3 :
-                var.sizing == "xlarge"  ? 4 :
-                var.sizing == "2xlarge" ? 6 :
-                1
-            )
+            instance_types = [local.s.artifactory_instance]
+            min_size       = 1
+            max_size       = 10
+            desired_size   = local.s.artifactory_desired
+
             block_device_mappings = {
                 xvda = {
                     device_name = "/dev/xvda"
                     ebs = {
-                        volume_type = "gp3"
-                        volume_size = (
-                            var.sizing == "large"   ? var.artifactory_disk_size_large :
-                            var.sizing == "xlarge"  ? var.artifactory_disk_size_large :
-                            var.sizing == "2xlarge" ? var.artifactory_disk_size_large :
-                            var.artifactory_disk_size_default
-                        )
-                        iops = (
-                            var.sizing == "large"   ? var.artifactory_disk_iops_large :
-                            var.sizing == "xlarge"  ? var.artifactory_disk_iops_large :
-                            var.sizing == "2xlarge" ? var.artifactory_disk_iops_large :
-                            var.artifactory_disk_iops_default
-                        )
-                        throughput = (
-                            var.sizing == "large"   ? var.artifactory_disk_throughput_large :
-                            var.sizing == "xlarge"  ? var.artifactory_disk_throughput_large :
-                            var.sizing == "2xlarge" ? var.artifactory_disk_throughput_large :
-                            var.artifactory_disk_throughput_default
-                        )
+                        volume_type           = "gp3"
+                        volume_size           = local.s.artifactory_disk_size
+                        iops                  = local.s.artifactory_disk_iops
+                        throughput            = local.s.artifactory_disk_throughput
                         delete_on_termination = true
                     }
                 }
@@ -117,21 +92,10 @@ module "eks" {
         nginx = {
             name = "${var.env_name}-nginx"
 
-            instance_types = [(
-                var.sizing == "xlarge"  ? var.nginx_node_size_large :
-                var.sizing == "2xlarge" ? var.nginx_node_size_large :
-                var.nginx_node_size_default
-            )]
-
-            min_size     = 1
-            max_size     = 10
-            desired_size = (
-                var.sizing == "medium"  ? 2 :
-                var.sizing == "large"   ? 2 :
-                var.sizing == "xlarge"  ? 2 :
-                var.sizing == "2xlarge" ? 3 :
-                1
-            )
+            instance_types = [local.s.nginx_instance]
+            min_size       = 1
+            max_size       = 10
+            desired_size   = local.s.nginx_desired
 
             labels = {
                 "group" = "nginx"
@@ -142,43 +106,19 @@ module "eks" {
         xray = {
             name = "${var.env_name}-xray"
 
-            instance_types = [(
-                var.sizing == "xlarge"  ? var.xray_node_size_xlarge :
-                var.sizing == "2xlarge" ? var.xray_node_size_xlarge :
-                var.xray_node_size_default
-            )]
-            min_size     = 1
-            max_size     = 10
-            desired_size = (
-                var.sizing == "medium"  ? 2 :
-                var.sizing == "large"   ? 3 :
-                var.sizing == "xlarge"  ? 4 :
-                var.sizing == "2xlarge" ? 6 :
-                1
-            )
+            instance_types = [local.s.xray_instance]
+            min_size       = 1
+            max_size       = 10
+            desired_size   = local.s.xray_desired
+
             block_device_mappings = {
                 xvda = {
                     device_name = "/dev/xvda"
                     ebs = {
-                        volume_type = "gp3"
-                        volume_size = (
-                            var.sizing == "large"   ? var.xray_disk_size_large :
-                            var.sizing == "xlarge"  ? var.xray_disk_size_large :
-                            var.sizing == "2xlarge" ? var.xray_disk_size_large :
-                            var.xray_disk_size_default
-                        )
-                        iops = (
-                            var.sizing == "large"   ? var.xray_disk_iops_large :
-                            var.sizing == "xlarge"  ? var.xray_disk_iops_large :
-                            var.sizing == "2xlarge" ? var.xray_disk_iops_large :
-                            var.xray_disk_iops_default
-                        )
-                        throughput = (
-                            var.sizing == "large"   ? var.xray_disk_throughput_large :
-                            var.sizing == "xlarge"  ? var.xray_disk_throughput_large :
-                            var.sizing == "2xlarge" ? var.xray_disk_throughput_large :
-                            var.xray_disk_throughput_default
-                        )
+                        volume_type           = "gp3"
+                        volume_size           = local.s.xray_disk_size
+                        iops                  = local.s.xray_disk_iops
+                        throughput            = local.s.xray_disk_throughput
                         delete_on_termination = true
                     }
                 }
@@ -194,10 +134,9 @@ module "eks" {
             name = "${var.env_name}-extra"
 
             instance_types = [var.extra_node_size]
-
-            min_size     = 0
-            max_size     = 3
-            desired_size = var.extra_node_count
+            min_size       = 0
+            max_size       = 3
+            desired_size   = var.extra_node_count
 
             labels = {
                 "group" = "extra"
@@ -220,17 +159,17 @@ resource "kubernetes_storage_class" "gp3_storage_class" {
             "storageclass.kubernetes.io/is-default-class" = "true"
         }
     }
-    storage_provisioner = "ebs.csi.aws.com"
-    volume_binding_mode = "WaitForFirstConsumer"
+    storage_provisioner    = "ebs.csi.aws.com"
+    volume_binding_mode    = "WaitForFirstConsumer"
     allow_volume_expansion = true
     parameters = {
         "fsType" = "ext4"
-        "type" = "gp3"
+        "type"   = "gp3"
     }
 }
 
 module "ebs_csi_irsa_role" {
-    source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+    source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
     version = "~> 5.0"
 
     role_name             = "ebs-csi-${module.eks.cluster_name}-${var.region}"

--- a/examples/terraform/jfrog-platform-aws-install/jfrog-platform.tf
+++ b/examples/terraform/jfrog-platform-aws-install/jfrog-platform.tf
@@ -13,6 +13,9 @@ provider "kubernetes" {
 
 # Fetch the JFrog Platform Helm chart and untar it to the current directory so we can use the sizing yaml files
 resource "null_resource" "fetch_platform_chart" {
+  triggers = {
+    version = var.jfrog_platform_chart_version
+  }
   provisioner "local-exec" {
     command = "rm -rf jfrog-platform-*.tgz"
   }
@@ -23,17 +26,9 @@ resource "null_resource" "fetch_platform_chart" {
 
 # Create an empty artifactory-license.yaml if missing
 resource "local_file" "empty_license" {
-  count = fileexists("${path.module}/artifactory-license.yaml") ? 0 : 1
+  count    = fileexists("${path.module}/artifactory-license.yaml") ? 0 : 1
   filename = "${path.module}/artifactory-license.yaml"
-  content = "## Empty file to satisfy Helm requirements"
-}
-
-# Set the cache-fs-size based on the sizing variable to 80% of the disk size
-locals {
-  cache-fs-size = (var.sizing == "large"  ? var.artifactory_disk_size_large * 0.8 :
-                  var.sizing == "xlarge"  ? var.artifactory_disk_size_large * 0.8 :
-                  var.sizing == "2xlarge" ? var.artifactory_disk_size_large * 0.8 :
-                  var.artifactory_disk_size_default * 0.8)
+  content  = "## Empty file to satisfy Helm requirements"
 }
 
 # Write the artifactory-custom.yaml file with the variables needed
@@ -42,7 +37,7 @@ resource "local_file" "jfrog_platform_values" {
   artifactory:
     artifactory:
       persistence:
-        maxCacheSize: "${local.cache-fs-size}000000000"
+        maxCacheSize: "${local.cache_fs_size}000000000"
         awsS3V3:
           region: "${var.region}"
           bucketName: "${local.artifactory_s3_bucket_name}"

--- a/examples/terraform/jfrog-platform-aws-install/locals.tf
+++ b/examples/terraform/jfrog-platform-aws-install/locals.tf
@@ -1,0 +1,139 @@
+# Centralized sizing configuration map.
+# All sizing-driven values are defined here and referenced as local.s.* throughout the configuration.
+# To add a new sizing tier, add an entry to sizing_config and update the variable validation in variables.tf.
+
+locals {
+  sizing_config = {
+    small = {
+      # EKS node instance types
+      artifactory_instance = var.artifactory_node_size_default
+      xray_instance        = var.xray_node_size_default
+      nginx_instance       = var.nginx_node_size_default
+
+      # EKS desired node counts
+      artifactory_desired = 1
+      xray_desired        = 1
+      nginx_desired       = 1
+
+      # Artifactory EBS data volume
+      artifactory_disk_size       = var.artifactory_disk_size_default
+      artifactory_disk_iops       = var.artifactory_disk_iops_default
+      artifactory_disk_throughput = var.artifactory_disk_throughput_default
+
+      # Xray EBS data volume
+      xray_disk_size       = var.xray_disk_size_default
+      xray_disk_iops       = var.xray_disk_iops_default
+      xray_disk_throughput = var.xray_disk_throughput_default
+
+      # RDS instance classes
+      artifactory_rds_instance = var.artifactory_rds_size_default
+      xray_rds_instance        = var.xray_rds_size_default
+
+      # RDS allocated storage (GiB)
+      artifactory_rds_disk = var.artifactory_rds_disk_size_default
+      xray_rds_disk        = var.xray_rds_disk_size_default
+    }
+
+    medium = {
+      artifactory_instance = var.artifactory_node_size_default
+      xray_instance        = var.xray_node_size_default
+      nginx_instance       = var.nginx_node_size_default
+
+      artifactory_desired = 2
+      xray_desired        = 2
+      nginx_desired       = 2
+
+      artifactory_disk_size       = var.artifactory_disk_size_default
+      artifactory_disk_iops       = var.artifactory_disk_iops_default
+      artifactory_disk_throughput = var.artifactory_disk_throughput_default
+
+      xray_disk_size       = var.xray_disk_size_default
+      xray_disk_iops       = var.xray_disk_iops_default
+      xray_disk_throughput = var.xray_disk_throughput_default
+
+      artifactory_rds_instance = var.artifactory_rds_size_medium
+      xray_rds_instance        = var.xray_rds_size_medium
+
+      artifactory_rds_disk = var.artifactory_rds_disk_size_medium
+      xray_rds_disk        = var.xray_rds_disk_size_medium
+    }
+
+    large = {
+      artifactory_instance = var.artifactory_node_size_large
+      xray_instance        = var.xray_node_size_default
+      nginx_instance       = var.nginx_node_size_default
+
+      artifactory_desired = 3
+      xray_desired        = 3
+      nginx_desired       = 2
+
+      artifactory_disk_size       = var.artifactory_disk_size_large
+      artifactory_disk_iops       = var.artifactory_disk_iops_large
+      artifactory_disk_throughput = var.artifactory_disk_throughput_large
+
+      xray_disk_size       = var.xray_disk_size_large
+      xray_disk_iops       = var.xray_disk_iops_large
+      xray_disk_throughput = var.xray_disk_throughput_large
+
+      artifactory_rds_instance = var.artifactory_rds_size_large
+      xray_rds_instance        = var.xray_rds_size_large
+
+      artifactory_rds_disk = var.artifactory_rds_disk_size_large
+      xray_rds_disk        = var.xray_rds_disk_size_large
+    }
+
+    xlarge = {
+      artifactory_instance = var.artifactory_node_size_large
+      xray_instance        = var.xray_node_size_xlarge
+      nginx_instance       = var.nginx_node_size_large
+
+      artifactory_desired = 4
+      xray_desired        = 4
+      nginx_desired       = 2
+
+      artifactory_disk_size       = var.artifactory_disk_size_large
+      artifactory_disk_iops       = var.artifactory_disk_iops_large
+      artifactory_disk_throughput = var.artifactory_disk_throughput_large
+
+      xray_disk_size       = var.xray_disk_size_large
+      xray_disk_iops       = var.xray_disk_iops_large
+      xray_disk_throughput = var.xray_disk_throughput_large
+
+      artifactory_rds_instance = var.artifactory_rds_size_xlarge
+      xray_rds_instance        = var.xray_rds_size_xlarge
+
+      artifactory_rds_disk = var.artifactory_rds_disk_size_xlarge
+      xray_rds_disk        = var.xray_rds_disk_size_xlarge
+    }
+
+    "2xlarge" = {
+      artifactory_instance = var.artifactory_node_size_large
+      xray_instance        = var.xray_node_size_xlarge
+      nginx_instance       = var.nginx_node_size_large
+
+      artifactory_desired = 6
+      xray_desired        = 6
+      nginx_desired       = 3
+
+      artifactory_disk_size       = var.artifactory_disk_size_large
+      artifactory_disk_iops       = var.artifactory_disk_iops_large
+      artifactory_disk_throughput = var.artifactory_disk_throughput_large
+
+      xray_disk_size       = var.xray_disk_size_large
+      xray_disk_iops       = var.xray_disk_iops_large
+      xray_disk_throughput = var.xray_disk_throughput_large
+
+      artifactory_rds_instance = var.artifactory_rds_size_2xlarge
+      xray_rds_instance        = var.xray_rds_size_2xlarge
+
+      artifactory_rds_disk = var.artifactory_rds_disk_size_2xlarge
+      xray_rds_disk        = var.xray_rds_disk_size_2xlarge
+    }
+  }
+
+  # Shorthand for the selected sizing tier — all resources use local.s.*
+  s = local.sizing_config[var.sizing]
+
+  # Artifactory cache size: 80% of the data disk, expressed in bytes for the Helm value
+  cache_fs_size = local.s.artifactory_disk_size * 0.8
+}

--- a/examples/terraform/jfrog-platform-aws-install/metrics.tf
+++ b/examples/terraform/jfrog-platform-aws-install/metrics.tf
@@ -4,6 +4,7 @@ resource "helm_release" "metrics_server" {
 
   name       = "metrics-server"
   chart      = "metrics-server"
+  version    = var.metrics_server_chart_version
   namespace  = "kube-system"
 
   # Repository to install the chart from

--- a/examples/terraform/jfrog-platform-aws-install/rds.tf
+++ b/examples/terraform/jfrog-platform-aws-install/rds.tf
@@ -1,4 +1,4 @@
-# This file creates the RDS instances for Artifactory and Xray
+# This file creates the RDS instances for Artifactory, Xray, and Catalog
 
 resource "aws_db_subnet_group" "jfrog_subnet_group" {
   name       = "${var.env_name}-subnet-group"
@@ -11,34 +11,20 @@ resource "aws_db_subnet_group" "jfrog_subnet_group" {
 }
 
 resource "aws_db_instance" "artifactory_db" {
-  identifier       = "artifactory-db-${var.env_name}"
-  engine           = "postgres"
-  engine_version   = var.rds_postgres_version
+  identifier     = "artifactory-db-${var.env_name}"
+  engine         = "postgres"
+  engine_version = var.rds_postgres_version
 
-  # Set the instance class based on the sizing variable
-  instance_class = (
-    var.sizing == "medium"  ? var.artifactory_rds_size_medium :
-    var.sizing == "large"   ? var.artifactory_rds_size_large :
-    var.sizing == "xlarge"  ? var.artifactory_rds_size_xlarge :
-    var.sizing == "2xlarge" ? var.artifactory_rds_size_2xlarge :
-    var.artifactory_rds_size_default
-  )
-
+  instance_class    = local.s.artifactory_rds_instance
   storage_type      = "gp3"
-  allocated_storage = (
-    var.sizing == "medium"  ? var.artifactory_rds_disk_size_medium :
-    var.sizing == "large"   ? var.artifactory_rds_disk_size_large :
-    var.sizing == "xlarge"  ? var.artifactory_rds_disk_size_xlarge :
-    var.sizing == "2xlarge" ? var.artifactory_rds_disk_size_2xlarge :
-    var.artifactory_rds_disk_size_default
-  )
+  allocated_storage = local.s.artifactory_rds_disk
 
-  max_allocated_storage  = var.artifactory_rds_disk_max_size
-  storage_encrypted      = true
+  max_allocated_storage = var.artifactory_rds_disk_max_size
+  storage_encrypted     = true
 
-  db_name                = var.artifactory_db_name
-  username               = var.artifactory_db_username
-  password               = var.artifactory_db_password
+  db_name  = var.artifactory_db_name
+  username = var.artifactory_db_username
+  password = var.artifactory_db_password
 
   vpc_security_group_ids = [aws_security_group.rds_sg.id]
   db_subnet_group_name   = aws_db_subnet_group.jfrog_subnet_group.name
@@ -51,33 +37,20 @@ resource "aws_db_instance" "artifactory_db" {
 }
 
 resource "aws_db_instance" "xray_db" {
-  identifier       = "xray-db-${var.env_name}"
-  engine           = "postgres"
-  engine_version   = var.rds_postgres_version
-  # Set the instance class based on the sizing variable
-  instance_class = (
-    var.sizing == "medium"  ? var.xray_rds_size_medium :
-    var.sizing == "large"   ? var.xray_rds_size_large :
-    var.sizing == "xlarge"  ? var.xray_rds_size_xlarge :
-    var.sizing == "2xlarge" ? var.xray_rds_size_2xlarge :
-    var.xray_rds_size_default
-  )
+  identifier     = "xray-db-${var.env_name}"
+  engine         = "postgres"
+  engine_version = var.rds_postgres_version
 
+  instance_class    = local.s.xray_rds_instance
   storage_type      = "gp3"
-  allocated_storage = (
-    var.sizing == "medium"  ? var.xray_rds_disk_size_medium :
-    var.sizing == "large"   ? var.xray_rds_disk_size_large :
-    var.sizing == "xlarge"  ? var.xray_rds_disk_size_xlarge :
-    var.sizing == "2xlarge" ? var.xray_rds_disk_size_2xlarge :
-    var.xray_rds_disk_size_default
-  )
+  allocated_storage = local.s.xray_rds_disk
 
-  max_allocated_storage  = var.xray_rds_disk_max_size
-  storage_encrypted      = true
+  max_allocated_storage = var.xray_rds_disk_max_size
+  storage_encrypted     = true
 
-  db_name                = var.xray_db_name
-  username               = var.xray_db_username
-  password               = var.xray_db_password
+  db_name  = var.xray_db_name
+  username = var.xray_db_username
+  password = var.xray_db_password
 
   vpc_security_group_ids = [aws_security_group.rds_sg.id]
   db_subnet_group_name   = aws_db_subnet_group.jfrog_subnet_group.name
@@ -90,21 +63,20 @@ resource "aws_db_instance" "xray_db" {
 }
 
 resource "aws_db_instance" "catalog_db" {
-  identifier       = "catalog-db-${var.env_name}"
-  engine           = "postgres"
-  engine_version   = var.rds_postgres_version
-  instance_class   = var.catalog_rds_size_default
+  identifier     = "catalog-db-${var.env_name}"
+  engine         = "postgres"
+  engine_version = var.rds_postgres_version
+  instance_class = var.catalog_rds_size_default
 
   storage_type      = "gp3"
   allocated_storage = var.catalog_rds_disk_size_default
 
+  max_allocated_storage = var.catalog_rds_disk_max_size
+  storage_encrypted     = true
 
-  max_allocated_storage  = var.catalog_rds_disk_max_size
-  storage_encrypted      = true
-
-  db_name                = var.catalog_db_name
-  username               = var.catalog_db_username
-  password               = var.catalog_db_password
+  db_name  = var.catalog_db_name
+  username = var.catalog_db_username
+  password = var.catalog_db_password
 
   vpc_security_group_ids = [aws_security_group.rds_sg.id]
   db_subnet_group_name   = aws_db_subnet_group.jfrog_subnet_group.name

--- a/examples/terraform/jfrog-platform-aws-install/s3.tf
+++ b/examples/terraform/jfrog-platform-aws-install/s3.tf
@@ -6,8 +6,9 @@ locals {
 resource "aws_s3_bucket" "artifactory_binarystore" {
   bucket = local.artifactory_s3_bucket_name
 
-  # WARNING: This will force the bucket to be destroyed even if it's not empty
-  force_destroy = true
+  # WARNING: force_destroy = true allows the bucket to be destroyed even if it contains objects.
+  # Set s3_force_destroy = false in terraform.tfvars to protect against accidental data loss.
+  force_destroy = var.s3_force_destroy
 
   tags = {
     Group = var.common_tag

--- a/examples/terraform/jfrog-platform-aws-install/variables.tf
+++ b/examples/terraform/jfrog-platform-aws-install/variables.tf
@@ -1,301 +1,391 @@
 # Setup the required variables
 
 variable "region" {
-  default = "us-east-1"
+  description = "The AWS region to deploy resources into"
+  default     = "us-east-1"
 }
 
 variable "env_name" {
-  default = "jfrog-platform"
+  description = "The environment name, used to prefix resource names and tags"
+  default     = "jfrog-platform"
 }
 
-# WARNING: CIDR "0.0.0.0/0" is full public access to the cluster. You should use a more restrictive CIDR
+# WARNING: CIDR "0.0.0.0/0" is full public access to the cluster. Use a more restrictive CIDR.
 variable "cluster_public_access_cidrs" {
-  default = ["0.0.0.0/0"]
+  description = "List of CIDR blocks allowed to access the EKS cluster API endpoint publicly"
+  default     = ["0.0.0.0/0"]
 }
 
 variable "vpc_cidr" {
-  default = "10.0.0.0/16"
+  description = "The CIDR block for the VPC"
+  default     = "10.0.0.0/16"
 }
 
 variable "public_subnet_cidrs" {
-  default = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  description = "List of CIDR blocks for public subnets (one per availability zone)"
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 }
 
 variable "private_subnet_cidrs" {
-  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  description = "List of CIDR blocks for private subnets (one per availability zone)"
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 variable "kubernetes_version" {
-  default = "1.34"
+  description = "The Kubernetes version for the EKS cluster"
+  default     = "1.35"
 }
 
 variable "rds_postgres_version" {
-  default = "17.7"
+  description = "The PostgreSQL engine version for all RDS instances"
+  default     = "17.7"
 }
 
 variable "artifactory_rds_size_default" {
-  default = "db.m8g.2xlarge"
+  description = "RDS instance class for Artifactory database (small sizing)"
+  default     = "db.m8g.2xlarge"
 }
 
 variable "artifactory_rds_size_medium" {
-  default = "db.m8g.4xlarge"
+  description = "RDS instance class for Artifactory database (medium sizing)"
+  default     = "db.m8g.4xlarge"
 }
 
 variable "artifactory_rds_size_large" {
-  default = "db.m8g.8xlarge"
+  description = "RDS instance class for Artifactory database (large sizing)"
+  default     = "db.m8g.8xlarge"
 }
 
 variable "artifactory_rds_size_xlarge" {
-  default = "db.m8g.12xlarge"
+  description = "RDS instance class for Artifactory database (xlarge sizing)"
+  default     = "db.m8g.12xlarge"
 }
 
 variable "artifactory_rds_size_2xlarge" {
-  default = "db.m8g.16xlarge"
+  description = "RDS instance class for Artifactory database (2xlarge sizing)"
+  default     = "db.m8g.16xlarge"
 }
 
 variable "artifactory_rds_disk_size_default" {
-  default = 100
+  description = "Allocated storage in GiB for Artifactory RDS (small sizing)"
+  default     = 100
 }
 
 variable "artifactory_rds_disk_size_medium" {
-  default = 250
+  description = "Allocated storage in GiB for Artifactory RDS (medium sizing)"
+  default     = 250
 }
 
 variable "artifactory_rds_disk_size_large" {
-  default = 500
+  description = "Allocated storage in GiB for Artifactory RDS (large sizing)"
+  default     = 500
 }
 
 variable "artifactory_rds_disk_size_xlarge" {
-  default = 1000
+  description = "Allocated storage in GiB for Artifactory RDS (xlarge sizing)"
+  default     = 1000
 }
 
 variable "artifactory_rds_disk_size_2xlarge" {
-  default = 1500
+  description = "Allocated storage in GiB for Artifactory RDS (2xlarge sizing)"
+  default     = 1500
 }
 
 variable "artifactory_rds_disk_max_size" {
-  default = 2000
+  description = "Maximum auto-scaling storage in GiB for Artifactory RDS"
+  default     = 2000
 }
 
 variable "catalog_rds_size_default" {
-  default = "db.t4g.micro"
+  description = "RDS instance class for Catalog database"
+  default     = "db.t4g.micro"
 }
 
 variable "catalog_rds_disk_size_default" {
-  default = 20
+  description = "Allocated storage in GiB for Catalog RDS"
+  default     = 20
 }
 
 variable "catalog_rds_disk_max_size" {
-  default = 50
+  description = "Maximum auto-scaling storage in GiB for Catalog RDS"
+  default     = 50
 }
 
 variable "xray_rds_size_default" {
-  default = "db.m8g.xlarge"
+  description = "RDS instance class for Xray database (small sizing)"
+  default     = "db.m8g.xlarge"
 }
 
 variable "xray_rds_size_medium" {
-  default = "db.m8g.2xlarge"
+  description = "RDS instance class for Xray database (medium sizing)"
+  default     = "db.m8g.2xlarge"
 }
 
 variable "xray_rds_size_large" {
-  default = "db.m8g.4xlarge"
+  description = "RDS instance class for Xray database (large sizing)"
+  default     = "db.m8g.4xlarge"
 }
 
 variable "xray_rds_size_xlarge" {
-  default = "db.m8g.8xlarge"
+  description = "RDS instance class for Xray database (xlarge sizing)"
+  default     = "db.m8g.8xlarge"
 }
 
 variable "xray_rds_size_2xlarge" {
-  default = "db.m8g.12xlarge"
+  description = "RDS instance class for Xray database (2xlarge sizing)"
+  default     = "db.m8g.12xlarge"
 }
 
 variable "xray_rds_disk_size_default" {
-  default = 100
+  description = "Allocated storage in GiB for Xray RDS (small sizing)"
+  default     = 100
 }
 
 variable "xray_rds_disk_size_medium" {
-  default = 250
+  description = "Allocated storage in GiB for Xray RDS (medium sizing)"
+  default     = 250
 }
 
 variable "xray_rds_disk_size_large" {
-  default = 500
+  description = "Allocated storage in GiB for Xray RDS (large sizing)"
+  default     = 500
 }
 
 variable "xray_rds_disk_size_xlarge" {
-  default = 1000
+  description = "Allocated storage in GiB for Xray RDS (xlarge sizing)"
+  default     = 1000
 }
 
 variable "xray_rds_disk_size_2xlarge" {
-  default = 1500
+  description = "Allocated storage in GiB for Xray RDS (2xlarge sizing)"
+  default     = 1500
 }
 
 variable "xray_rds_disk_max_size" {
-  default = 2000
+  description = "Maximum auto-scaling storage in GiB for Xray RDS"
+  default     = 2000
 }
 
 variable "artifactory_node_size_default" {
-  default = "m8g.2xlarge"
+  description = "EC2 instance type for Artifactory node group (small/medium sizing)"
+  default     = "m8g.2xlarge"
 }
 
 variable "artifactory_node_size_large" {
-  default = "m8g.4xlarge"
+  description = "EC2 instance type for Artifactory node group (large/xlarge/2xlarge sizing)"
+  default     = "m8g.4xlarge"
 }
 
 variable "artifactory_disk_size_default" {
-  default = 500
+  description = "EBS data volume size in GiB for Artifactory nodes (small/medium sizing)"
+  default     = 500
 }
 
 variable "artifactory_disk_size_large" {
-  default = 1000
+  description = "EBS data volume size in GiB for Artifactory nodes (large/xlarge/2xlarge sizing)"
+  default     = 1000
 }
 
 variable "artifactory_disk_iops_default" {
-  default = 3000
+  description = "EBS data volume IOPS for Artifactory nodes (small/medium sizing)"
+  default     = 3000
 }
 
 variable "artifactory_disk_iops_large" {
-  default = 6000
+  description = "EBS data volume IOPS for Artifactory nodes (large/xlarge/2xlarge sizing)"
+  default     = 6000
 }
 
 variable "artifactory_disk_throughput_default" {
-  default = 500
+  description = "EBS data volume throughput in MiB/s for Artifactory nodes (small/medium sizing)"
+  default     = 500
 }
 
 variable "artifactory_disk_throughput_large" {
-  default = 1000
+  description = "EBS data volume throughput in MiB/s for Artifactory nodes (large/xlarge/2xlarge sizing)"
+  default     = 1000
 }
 
 variable "xray_node_size_default" {
-  default = "c8g.2xlarge"
+  description = "EC2 instance type for Xray node group (small/medium/large sizing)"
+  default     = "c8g.2xlarge"
 }
 
 variable "xray_node_size_xlarge" {
-  default = "c8g.4xlarge"
+  description = "EC2 instance type for Xray node group (xlarge/2xlarge sizing)"
+  default     = "c8g.4xlarge"
 }
 
 variable "xray_disk_size_default" {
-  default = 100
+  description = "EBS data volume size in GiB for Xray nodes (small/medium sizing)"
+  default     = 100
 }
 
 variable "xray_disk_size_large" {
-  default = 200
+  description = "EBS data volume size in GiB for Xray nodes (large/xlarge/2xlarge sizing)"
+  default     = 200
 }
 
 variable "xray_disk_iops_default" {
-  default = 3000
+  description = "EBS data volume IOPS for Xray nodes (small/medium sizing)"
+  default     = 3000
 }
 
 variable "xray_disk_iops_large" {
-  default = 6000
+  description = "EBS data volume IOPS for Xray nodes (large/xlarge/2xlarge sizing)"
+  default     = 6000
 }
 
 variable "xray_disk_throughput_default" {
-  default = 500
+  description = "EBS data volume throughput in MiB/s for Xray nodes (small/medium sizing)"
+  default     = 500
 }
 
 variable "xray_disk_throughput_large" {
-  default = 1000
+  description = "EBS data volume throughput in MiB/s for Xray nodes (large/xlarge/2xlarge sizing)"
+  default     = 1000
 }
 
 variable "nginx_node_size_default" {
-  default = "c8g.xlarge"
+  description = "EC2 instance type for Nginx ingress node group (small/medium/large sizing)"
+  default     = "c8g.xlarge"
 }
 
 variable "nginx_node_size_large" {
-  default = "c8g.2xlarge"
+  description = "EC2 instance type for Nginx ingress node group (xlarge/2xlarge sizing)"
+  default     = "c8g.2xlarge"
 }
 
 variable "extra_node_count" {
-  default = "3"
+  description = "Desired number of nodes in the extra (general-purpose) node group"
+  default     = 3
 }
 
 variable "extra_node_size" {
-  default = "c8g.xlarge"
+  description = "EC2 instance type for the extra (general-purpose) node group"
+  default     = "c8g.xlarge"
 }
 
 variable "artifactory_db_name" {
-  description = "The database name"
+  description = "The Artifactory database name"
   default     = "artifactory"
 }
 
 variable "artifactory_db_username" {
-  description = "The username for the database"
+  description = "The username for the Artifactory database"
   default     = "artifactory"
 }
 
 variable "artifactory_db_password" {
-  description = "The password for the database"
+  description = "The password for the Artifactory PostgreSQL database. Must be set in terraform.tfvars."
   sensitive   = true
-  default     = "Password321"
+  default     = null
+
+  validation {
+    condition     = var.artifactory_db_password != null
+    error_message = "artifactory_db_password must be set in terraform.tfvars."
+  }
 }
 
 variable "xray_db_name" {
-  description = "The database name"
+  description = "The Xray database name"
   default     = "xray"
 }
 
 variable "xray_db_username" {
-  description = "The username for the database"
+  description = "The username for the Xray database"
   default     = "xray"
 }
 
 variable "xray_db_password" {
-  description = "The password for the database"
+  description = "The password for the Xray PostgreSQL database. Must be set in terraform.tfvars."
   sensitive   = true
-  default     = "PasswordX321"
+  default     = null
+
+  validation {
+    condition     = var.xray_db_password != null
+    error_message = "xray_db_password must be set in terraform.tfvars."
+  }
 }
 
 variable "catalog_db_name" {
-  description = "The database name"
+  description = "The Catalog database name"
   default     = "ctlg"
 }
 
 variable "catalog_db_username" {
-  description = "The username for the database"
+  description = "The username for the Catalog database"
   default     = "ctlg"
 }
 
 variable "catalog_db_password" {
-  description = "The password for the database"
+  description = "The password for the Catalog PostgreSQL database. Must be set in terraform.tfvars."
   sensitive   = true
-  default     = "PasswordC321"
+  default     = null
+
+  validation {
+    condition     = var.catalog_db_password != null
+    error_message = "catalog_db_password must be set in terraform.tfvars."
+  }
 }
 
-# The AMI type for the EKS Managed Node Groups. 
+# The AMI type for the EKS Managed Node Groups.
 # Currently using Graviton (ARM64) instances, with the AL2023_ARM_64_STANDARD image type.
 # For AMD64 instances, use the AL2023_x86_64_STANDARD image type.
 # Make sure to adjust the instance types accordingly.
 variable "ami_type" {
   description = "The AMI type for the EKS Managed Node Groups."
-  default = "AL2023_ARM_64_STANDARD"
+  default     = "AL2023_ARM_64_STANDARD"
 }
 
 variable "jfrog_charts_repository" {
-  default = "https://charts.jfrog.io"
+  description = "The Helm repository URL for JFrog charts"
+  default     = "https://charts.jfrog.io"
 }
 
 variable "jfrog_platform_chart_version" {
   description = "The jfrog-platform chart version"
-  default = ""
-  
+  default     = ""
+
   validation {
     condition     = var.jfrog_platform_chart_version != null && var.jfrog_platform_chart_version != ""
-    error_message = "The jfrog_platform_chart_version variable must be set. Specify a valid chart version in a terraform.tfvars file (e.g., 'jfrog_platform_chart_version = \"11.1.9\"')."
+    error_message = "The jfrog_platform_chart_version variable must be set. Specify a valid chart version in a terraform.tfvars file (e.g., 'jfrog_platform_chart_version = \"11.5.0\"')."
   }
 }
 
 variable "deploy_metrics_server" {
-  default = true
+  description = "If true, deploy the metrics-server Helm chart into kube-system"
+  default     = true
+}
+
+variable "metrics_server_chart_version" {
+  description = "The metrics-server Helm chart version to deploy"
+  default     = "3.12.2"
+}
+
+variable "eks_root_volume_size" {
+  description = "Root EBS volume size in GiB for all EKS node groups"
+  default     = 50
+}
+
+variable "eks_root_throughput" {
+  description = "Root EBS volume throughput in MiB/s for all EKS node groups"
+  default     = 125
+}
+
+variable "s3_force_destroy" {
+  description = "If true, the S3 bucket can be destroyed even when it contains objects. WARNING: set to false in production to prevent accidental data loss."
+  default     = true
 }
 
 variable "common_tag" {
   description = "The 'Group' tag to apply to all resources"
-  default = "jfrog"
+  default     = "jfrog"
 }
 
 variable "sizing" {
   type        = string
-  description = "The sizing templates for the infrastructure and Artifactory"
+  description = "The sizing template for the infrastructure and Artifactory. Controls instance types, node counts, disk sizes, and RDS classes."
   default     = "small"
 
   validation {


### PR DESCRIPTION
**Upgrade and improve AWS Terraform example**

  - Bump JFrog Platform chart to 11.5.0, metrics-server chart to 3.12.2 (pinned), Kubernetes to 1.35, PostgreSQL to 17.7
  - Replace ~15 repeated sizing ternary chains with a single locals.tf sizing map (local.s.*) — adding a new tier now requires editing
  one block
  - Remove hardcoded database password defaults; passwords must now be set explicitly in `terraform.tfvars` (validated at plan time)
  - Fix null_resource chart fetch to re-run when chart version changes (was missing triggers)
  - Parameterize EKS root volume size/throughput and S3 force_destroy
  - Add description to all variables that lacked one
