### PR TITLE
[artifactory-ha] Add optional pod management policy

### DIFF
--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -68,6 +68,9 @@ metadata:
 {{- end }}
 spec:
   serviceName: {{ template "artifactory-ha.primary.name" . }}
+  {{- with .Values.artifactory.statefulset.podManagementPolicy }}
+  podManagementPolicy: {{ . }}
+  {{- end }}
   replicas: {{ .Values.artifactory.primary.replicaCount }}
   updateStrategy: {{- toYaml .Values.artifactory.primary.updateStrategy | nindent 4}}
   selector:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds (optional) podManagementPolicy to the artifactory-ha charts.
-> Optional to ensure backwards compatibility


**Special notes for your reviewer**:
We've tested this on our staging environment already and it works like a charm!

Sidenote, I've discovered an issue with the linting process during my contribution steps.
On both master and my branch with its changes the same output appears when running `make lint -- --charts stable/artifactory-ha`
```
❯ make lint -- --charts stable/artifactory-ha
test/lint-charts.sh
Installing kubeval...
Local run, not downloading kubeval cli...
Installing helm...
Local run, not downloading helm cli...
Error response from daemon: No such container: ct
Linting charts...
Version increment checking disabled.

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 artifactory-ha => (version: "107.146.8", path: "stable/artifactory-ha")
------------------------------------------------------------------------------------------------------------------------

"jfrog" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "jfrog" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading postgresql from repo https://charts.jfrog.io/
Deleting outdated charts
Linting chart 'artifactory-ha => (version: "107.146.8", path: "stable/artifactory-ha")'
Validating /workdir/stable/artifactory-ha/Chart.yaml...
Validation success! 👍

Linting chart with values file 'stable/artifactory-ha/ci/access-tls-values.yaml'...

==> Linting stable/artifactory-ha
[ERROR] templates/: template: artifactory-ha/templates/artifactory-node-statefulset.yaml:1:18: executing "artifactory-ha/templates/artifactory-node-statefulset.yaml" at <.Values.artifactory.node.replicaCount>: nil pointer evaluating interface {}.replicaCount

------------------------------------------------------------------------------------------------------------------------
 ✖︎ artifactory-ha => (version: "107.146.8", path: "stable/artifactory-ha") > Error waiting for process: exit status 1
Error: Error linting charts: Error processing charts
------------------------------------------------------------------------------------------------------------------------
Error linting charts: Error processing charts
make: *** [Makefile:56: lint] Error 1
```

As this occurs independently to my changes and since my chart change runs in our environment without issues, I have decided to open this PR as well as report the issues with the linting steps!