### PR TITLE
[artifactory] Add RTFS pod label values

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file
 * Added `nginx.httpUseProxyProtocol` and `nginx.httpsUseProxyProtocol` so NGINX can accept the HAProxy PROXY protocol on HTTP/HTTPS listeners. ([GH-2156](https://github.com/jfrog/charts/pull/2156))
 * Added dedicated PostgreSQL `type` and `driver` for RTFS to rendered `system.yaml` when RTFS uses its own PostgreSQL.
 * Fixed RTFS template validation so a non-PostgreSQL primary Artifactory database is allowed when RTFS uses a dedicated PostgreSQL database.
+* Added `rtfs.labels` to label the RTFS Deployment and pod template.
 
 ## [107.143.0] - Mar 30, 2026
 * Fixing duplicate volume names in the unified volume configuration

--- a/stable/artifactory-ha/templates/rtfs-deployment.yaml
+++ b/stable/artifactory-ha/templates/rtfs-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: {{ .Values.rtfs.name }}
+{{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.rtfs.deployment.labels }}
 {{ toYaml .Values.rtfs.deployment.labels | indent 4 }}
 {{- end }}
@@ -43,6 +46,9 @@ spec:
         component: {{ .Values.rtfs.name }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        {{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
     spec:
       {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
       {{- include "artifactory-ha.imagePullSecrets" . | indent 6 }}

--- a/stable/artifactory-ha/templates/rtfs/rtfs-deployment.yaml
+++ b/stable/artifactory-ha/templates/rtfs/rtfs-deployment.yaml
@@ -14,6 +14,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: {{ .Values.rtfs.name }}
+{{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.rtfs.deployment.labels }}
 {{ toYaml .Values.rtfs.deployment.labels | indent 4 }}
 {{- end }}
@@ -53,6 +56,9 @@ spec:
         component: {{ .Values.rtfs.name }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        {{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
     spec:
       {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
 {{- include "artifactory-ha.imagePullSecrets" . | indent 6 }}

--- a/stable/artifactory-ha/values.yaml
+++ b/stable/artifactory-ha/values.yaml
@@ -2172,6 +2172,8 @@ rtfs:
   internalRestPort: 8025
   apiContext: rtfs
   serviceAccountName: ""
+  ## Labels to add to the RTFS Deployment and pod template
+  labels: {}
   # If set to true, Service will wait until Artifactory is available before starting.
   # Set this to false if you're using an external Artifactory, meaning an Artifactory instance hosted at an external URL and not installed as part of this setup.
   waitForArtifactory: true

--- a/stable/artifactory/CHANGELOG.md
+++ b/stable/artifactory/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Fixed filebeat container image resolution to use `filebeat.image.registry` directly instead of being overridden by `global.imageRegistry`
 * Added dedicated PostgreSQL `type` and `driver` for RTFS to rendered `system.yaml` when RTFS uses its own PostgreSQL.
 * Fixed RTFS template validation so a non-PostgreSQL primary Artifactory database is allowed when RTFS uses a dedicated PostgreSQL database.
+* Added `rtfs.labels` to label the RTFS Deployment and pod template.
 
 ## [107.147.0] - Apr 2, 2026
 * Added support for Gateway API (Gateway, HTTPRoute)

--- a/stable/artifactory/templates/rtfs-deployment.yaml
+++ b/stable/artifactory/templates/rtfs-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: {{ .Values.rtfs.name }}
+{{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.rtfs.deployment.labels }}
 {{ toYaml .Values.rtfs.deployment.labels | indent 4 }}
 {{- end }}
@@ -43,6 +46,9 @@ spec:
         component: {{ .Values.rtfs.name }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        {{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
     spec:
       {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
   {{- include "artifactory.imagePullSecrets" . | indent 6 }}

--- a/stable/artifactory/templates/rtfs/rtfs-deployment.yaml
+++ b/stable/artifactory/templates/rtfs/rtfs-deployment.yaml
@@ -14,6 +14,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: {{ .Values.rtfs.name }}
+{{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.rtfs.deployment.labels }}
 {{ toYaml .Values.rtfs.deployment.labels | indent 4 }}
 {{- end }}
@@ -53,6 +56,9 @@ spec:
         component: {{ .Values.rtfs.name }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        {{- with .Values.rtfs.labels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
     spec:
       {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
 {{- include "artifactory.imagePullSecrets" . | indent 6 }}

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -2145,6 +2145,8 @@ rtfs:
   waitForArtifactory: true
   internalRestPort: 8025
   apiContext: rtfs
+  ## Labels to add to the RTFS Deployment and pod template
+  labels: {}
   ## Optional dedicated RTFS database (Artifactory 7.144+). When rtfs.database.type is postgresql, RTFS uses a separate database instead of the shared one; leave type unset to use the main Artifactory database (PostgreSQL only, see chart notes).
   ## If type is set, you must provide url here or database.secrets.url (each secret ref: name: <k8s Secret name>, key: <key holding the value>).
   ## Credentials: use inline url / user / password below, OR point database.secrets.url, .user, .password at existing Secrets. If database.secrets is used, reference Secrets for every credential you do not put inline; do not rely on the chart-generated RTFS DB Secret when any database.secrets entry is set.


### PR DESCRIPTION
#### PR Checklist
- [ ] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in values.yaml
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)

**What this PR does / why we need it**:

Adds a shared `rtfs.labels` value for the Artifactory and Artifactory HA charts, and renders those labels on both the RTFS Deployment metadata and the RTFS pod template metadata.

`rtfs.deployment.labels` is preserved as a Deployment-only label override. The new `rtfs.labels` mirrors the existing chart pattern used by workloads such as Artifactory and NGINX where a single labels value is applied to both the controller object and pods.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2309

**Verification**:

- `git diff --check`
- `rg 'rtfs\.labels|Labels to add to the RTFS Deployment' -n stable\artifactory stable\artifactory-ha`

I could not run `helm template`/`make lint` locally because this Windows workspace does not have `helm`, `kubectl`, or `kubeval` installed.

**Special notes for your reviewer**:

I left the chart version unchecked because there are active automated Artifactory release PRs in flight; happy to adjust the version bump if you prefer it in this PR.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.
