### PR TITLE
[artifactory-ha] Removed one selector label from PDB

### DIFF
--- a/stable/artifactory-ha/CHANGELOG.md
+++ b/stable/artifactory-ha/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file
 * Added `nginx.httpUseProxyProtocol` and `nginx.httpsUseProxyProtocol` so NGINX can accept the HAProxy PROXY protocol on HTTP/HTTPS listeners. ([GH-2156](https://github.com/jfrog/charts/pull/2156))
 * Added dedicated PostgreSQL `type` and `driver` for RTFS to rendered `system.yaml` when RTFS uses its own PostgreSQL.
 * Fixed RTFS template validation so a non-PostgreSQL primary Artifactory database is allowed when RTFS uses a dedicated PostgreSQL database.
+* Removed `component` label selector from PodDisruptionBudget to match selector of StatefulSet of `artifactory-primary`
 
 ## [107.143.0] - Mar 30, 2026
 * Fixing duplicate volume names in the unified volume configuration

--- a/stable/artifactory-ha/templates/artifactory-primary-pdb.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-pdb.yaml
@@ -16,7 +16,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      component: {{ .Values.artifactory.name }}
       app: {{ template "artifactory-ha.name" . }}
       role: {{ template "artifactory-ha.primary.name" . }}
       release: {{ .Release.Name }}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name (e.g. `[artifactory]`)


**What this PR does / why we need it**:
Extra label `component` in Artifactory primary PodDisruptionBudget prevents matching PodDisruptionBudget to StatefulSet, making automatic GKE node management unavailable.