### PR TITLE
Auto merge PRs

### DIFF
--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -169,7 +169,6 @@ jobs:
                 --title "[$PRODUCT] $CHART_VERSION" \
                 --notes-file "$NOTES_FILE" \
                 || echo "::warning::Release for $TAG may already exist"
-              rm -f "$NOTES_FILE"
 
               # Create PR for this product
               TITLE="[$PRODUCT] $CHART_VERSION release"
@@ -181,15 +180,27 @@ jobs:
 
               This is an automated update by the JFrog Charts update workflow."
 
-              gh pr create \
+              PR_URL=$(gh pr create \
                 --title "$TITLE" \
                 --body "$BODY" \
                 --base "${{ github.event.repository.default_branch }}" \
                 --head "$BRANCH" \
                 --label "automated" \
-                --label "update"
+                --label "update")
+              echo "✓ Created release and PR for $PRODUCT: $PR_URL"
 
-              echo "✓ Successfully created release and PR for $PRODUCT"
+              # Auto-merge only when the changelog has no GitHub references
+              # (e.g. "GH-2177"). Those usually point at issues/PRs that a
+              # human should review, so leave such PRs open.
+              if grep -qE 'GH-[0-9]+' "$NOTES_FILE"; then
+                echo "::notice::$PRODUCT changelog contains GitHub references (GH-...); leaving PR open for manual review"
+              else
+                echo "No GitHub references in changelog; auto-merging $PRODUCT PR"
+                gh pr merge "$PR_URL" --squash --delete-branch \
+                  || echo "::warning::auto-merge failed for $PRODUCT (checks/permissions?); PR left open"
+              fi
+
+              rm -f "$NOTES_FILE"
             else
               echo "No changes detected for $PRODUCT"
               # Clean up the branch if no changes


### PR DESCRIPTION
Remove redundant deletion of notes file after creating a release and PR.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[artifactory]`)


<!--
Thank you for contributing to jfrog/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

