### PR TITLE
[bridge] roll the pod when configuration changes

### DIFF
--- a/stable/bridge/CHANGELOG.md
+++ b/stable/bridge/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All changes to this chart will be documented in this file
 
+## [101.262.52] - Aug 28, 2026
+* Added `checksum/` annotations for the system.yaml and secrets templates so configuration changes roll the pod
+
 ## [101.213.0] - Jun 30, 2026
 * Switch initContainer image to echo-mini:20260629
 

--- a/stable/bridge/Chart.yaml
+++ b/stable/bridge/Chart.yaml
@@ -16,4 +16,4 @@ name: bridge
 sources:
 - https://github.com/jfrog/charts
 type: application
-version: 101.262.51
+version: 101.262.52

--- a/stable/bridge/templates/deployment.yaml
+++ b/stable/bridge/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/bridge-systemyaml: {{ include (print $.Template.BasePath "/system-yaml.yaml") . | sha256sum }}
+        checksum/bridge-secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.commonAnnotations }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] CHANGELOG.md updated
- [x] Title of the PR starts with chart name

**What this PR does / why we need it**:

`stable/bridge/templates/deployment.yaml` carries no `checksum/` annotation, so a `helm upgrade` that changes bridge's rendered configuration updates the Secret and reports `Upgrade complete` while **the pod keeps running the previous configuration** with `0` restarts.

This is worse than a normal config-reload gap because bridge reads `system.yaml` through an init container (`copy-system-yaml`, mounting the Secret at `/tmp/etc/system.yaml`), so the config can only ever be picked up on pod creation. Every status surface reads healthy in the meantime — Helm says `Upgrade complete`, the Secret is correct, the pod is `Running` — so an operator gets no signal that the service is stale. `kubectl rollout restart` is currently the only remedy.

Sibling charts already do this; bridge is the outlier:

| chart | `checksum/` annotations |
|---|---|
| artifactory | 9 |
| xray | 9 |
| distribution | 3 |
| catalog | 1 |
| wingman | 1 |
| **bridge** | **0** |

Annotations are added for both config-bearing templates (`system-yaml.yaml`, `secrets.yaml`) in the same idiom as `stable/catalog/templates/deployment.yaml`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2518

**Special notes for your reviewer**:

Verified by rendering, with a negative control so the annotations are shown to be neither inert nor over-eager:

| | `checksum/bridge-systemyaml` | `checksum/bridge-secrets` |
|---|---|---|
| baseline | `3ed837cb…` | `275bd086…` |
| config changed (`extraSystemYaml…logging.application.level=debug`) | **changed** → `c10bf30c…` | unchanged |
| non-config changed (`replicaCount=2`) | unchanged | unchanged |

So the pod rolls when configuration changes and not otherwise.

Note on the version bump: this and #2519 are independent fixes to the same chart and both claim `101.262.52`. Whichever merges second will need the bump renumbered — happy to rebase on request.

No README change — this adds no values.
