### PR TITLE
artifactory: split PEM certificate bundles in customCertificates init container

### DIFF
--- a/stable/artifactory-ha/templates/_helpers.tpl
+++ b/stable/artifactory-ha/templates/_helpers.tpl
@@ -513,7 +513,7 @@ Custom certificate copy command for jfbus
 {{- define "jfbus.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 
@@ -523,7 +523,7 @@ Custom certificate copy command for rtfs
 {{- define "rtfs.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 
@@ -533,7 +533,7 @@ Custom certificate copy command for artifactory
 {{- define "artifactory-ha.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 
@@ -1362,7 +1362,7 @@ Custom certificate copy command for jfmelt
 {{- define "jfmelt.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 

--- a/stable/artifactory/templates/_helpers.tpl
+++ b/stable/artifactory/templates/_helpers.tpl
@@ -448,7 +448,7 @@ Custom certificate copy command for jfbus
 {{- define "jfbus.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.jfbus.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 
@@ -458,7 +458,7 @@ Custom certificate copy command for rtfs
 {{- define "rtfs.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.rtfs.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 
@@ -468,7 +468,7 @@ Custom certificate copy command for artifactory
 {{- define "artifactory.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename "${file}")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.artifactory.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 
@@ -1343,7 +1343,7 @@ Custom certificate copy command for jfmelt
 {{- define "jfmelt.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.jfmelt.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 

--- a/stable/bridge/templates/_helpers.tpl
+++ b/stable/bridge/templates/_helpers.tpl
@@ -186,7 +186,7 @@ Custom certificate copy command
 {{- if or .Values.customCertificates.enabled .Values.global.customCertificates.enabled -}}
 echo "Copy custom certificates to /var/opt/jfrog/bridge/etc/security/keys/trusted";
 mkdir -p /var/opt/jfrog/bridge/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} /var/opt/jfrog/bridge/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="/var/opt/jfrog/bridge/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} /var/opt/jfrog/bridge/etc/security/keys/trusted; fi; fi done;
 if [ -f /var/opt/jfrog/bridge/etc/security/keys/trusted/tls.crt ]; then mv -v /var/opt/jfrog/bridge/etc/security/keys/trusted/tls.crt /var/opt/jfrog/bridge/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 {{- if .Values.tunnelClientCertificateSecretName -}}

--- a/stable/catalog/templates/_helpers.tpl
+++ b/stable/catalog/templates/_helpers.tpl
@@ -230,6 +230,6 @@ Custom certificate copy command
 {{- define "catalog.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}

--- a/stable/distribution/templates/_helpers.tpl
+++ b/stable/distribution/templates/_helpers.tpl
@@ -271,7 +271,7 @@ Custom certificate copy command
 {{- define "distribution.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.distribution.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 

--- a/stable/insight/templates/_helpers.tpl
+++ b/stable/insight/templates/_helpers.tpl
@@ -245,7 +245,7 @@ Custom certificate copy command
 {{- define "insight-server.copyCustomCerts" -}}
 echo "Copy custom certificates to {{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.insightServer.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 

--- a/stable/xray/templates/_helpers.tpl
+++ b/stable/xray/templates/_helpers.tpl
@@ -643,7 +643,7 @@ Custom certificate copy command
 {{- if or .Values.xray.customCertificates.enabled .Values.global.customCertificates.enabled -}}
 echo "Copy custom certificates to {{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted";
 mkdir -p {{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted;
-for file in $(ls -1 /tmp/certs/* | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cp -v ${file} {{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted; fi done;
+for file in $(ls -1 /tmp/certs/* 2>/dev/null | grep -v .key | grep -v ":" | grep -v grep); do if [ -f "${file}" ]; then cert_count=$(grep -c "BEGIN CERTIFICATE" "${file}" 2>/dev/null || echo 0); if [ "${cert_count}" -gt 1 ]; then echo "Splitting certificate bundle ${file}"; awk -v outdir="{{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted" -v base="$(basename \"${file}\")" '/-----BEGIN CERTIFICATE-----/ { n++; fname=sprintf("%s/%s-%03d.pem", outdir, base, n) } { if (n>0) print > fname }' "${file}"; else cp -v ${file} {{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted; fi; fi done;
 if [ -f {{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted/tls.crt ]; then mv -v {{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted/tls.crt {{ .Values.xray.persistence.mountPath }}/etc/security/keys/trusted/ca.crt; fi;
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Fixes #2419

When a customCertificates secret stores multiple CAs in one PEM bundle (for example from trust-manager), the init container now splits the bundle into individual certificate files before copying them into the truststore.

## Test plan
- [x] helm template stable/artifactory with customCertificates enabled and confirmed the init container script includes bundle splitting logic